### PR TITLE
Improved various parts of the codebase and performance.

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ use syn::{Expr, ExprArray, ExprLit, ExprTuple, Item, Lit};
 // all of the currently implemented ids for objects and properties as consts.
 // currently broken due to `kAXX` properties
 
-fn to_const_name(s: String) -> String {
+fn to_const_name(s: &str) -> String {
     let mut seen_underscore = false;
     s.chars()
         .map(|c| {
@@ -37,7 +37,7 @@ fn handle_tuple(buffer: &mut String, tuple: ExprTuple) {
             }
         }
     }
-    let const_name = to_const_name(name);
+    let const_name = to_const_name(&name);
     writeln!(buffer, "    pub const {const_name}: i32 = {id};").unwrap();
 }
 
@@ -80,7 +80,7 @@ fn main() {
             let id = split.next().unwrap();
             let mut tuple_split = split.next().unwrap().split(", ");
             let desc = tuple_split.next().unwrap();
-            let const_name = to_const_name(desc.to_string());
+            let const_name = to_const_name(desc);
 
             writeln!(
                 properties_out_str,

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -7,7 +7,7 @@ fn main() -> Result<(), GDError> {
     // Get level data, which is None only if it hasn't been initialized.
     if let Some(data) = level.get_decrypted_data_ref() {
         // Add group 42 to all objects
-        for obj in data.objects.iter_mut() {
+        for obj in &mut data.objects {
             obj.config.add_group(Group::Regular(42));
         }
     }

--- a/src/core.rs
+++ b/src/core.rs
@@ -56,6 +56,7 @@ impl Display for GDError {
 }
 
 /// Returns path of CCLocalLevels.dat if it exists
+#[must_use]
 pub fn get_local_levels_path() -> Option<PathBuf> {
     if let Ok(local_appdata) = env::var("LOCALAPPDATA")
         && Path::new(&local_appdata).exists()
@@ -67,7 +68,8 @@ pub fn get_local_levels_path() -> Option<PathBuf> {
 }
 
 /// Replaces Robtop's plist format with actual plist tags; i.e. `<s>` becomes `<string>`
-pub fn proper_plist_tags(s: String) -> String {
+#[must_use]
+pub fn proper_plist_tags(s: &str) -> String {
     // replace gd plist with proper plist
     // using aho-corasick for single-pass instead of many .replace()s
     let find = &[
@@ -92,11 +94,12 @@ pub fn proper_plist_tags(s: String) -> String {
         "</real>",
     ];
     let ac = AhoCorasick::new(find).unwrap();
-    ac.replace_all(&s, replace)
+    ac.replace_all(s, replace)
 }
 
 /// Quick function for decoding base64 bytes
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn b64_decode<T: AsRef<[u8]> + Debug>(encoded: T) -> Vec<u8> {
     base64::engine::general_purpose::URL_SAFE
         .decode(encoded)
@@ -104,7 +107,8 @@ pub fn b64_decode<T: AsRef<[u8]> + Debug>(encoded: T) -> Vec<u8> {
 }
 
 /// Quick function for encoding base64 bytes
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn b64_encode(encoded: Vec<u8>) -> String {
     base64::engine::general_purpose::URL_SAFE.encode(encoded)
 }

--- a/src/deserialiser.rs
+++ b/src/deserialiser.rs
@@ -34,11 +34,13 @@ pub fn decompress(mut data: Vec<u8>) -> Result<Vec<u8>, GDError> {
 /// * `data`: encrypted payload
 ///
 /// Returns the raw file contents as a `Vec<u8>`
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn decrypt(mut data: Vec<u8>) -> Vec<u8> {
     for c in &mut data {
-        *c ^= 11;
+        *c ^= 0xb;
     }
+
     decompress(data).unwrap()
 }
 
@@ -48,7 +50,8 @@ pub fn decode_levels_to_string() -> Result<String, GDError> {
         Ok(v) => v,
         Err(e) => return Err(GDError::Io(e)),
     };
+
     let data = decrypt(savefile);
 
-    Ok(String::from_utf8(data.to_vec()).unwrap())
+    Ok(String::from_utf8(data).unwrap())
 }

--- a/src/gdlevel.rs
+++ b/src/gdlevel.rs
@@ -5,6 +5,7 @@ use std::{
     fs::{self, read, write},
     io::Cursor,
     path::PathBuf,
+    str::from_utf8,
 };
 
 use crate::{core::GDError, gdobj::Group};
@@ -42,7 +43,7 @@ pub struct Levels {
 }
 
 /// This struct contains level data that has not yet been decrypted
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct EncryptedLevelData {
     /// Raw level data
     pub data: String,
@@ -71,13 +72,13 @@ pub enum LevelState {
 
 impl Levels {
     /// Returns the levels in CCLocalLevels.dat if retrievable
-    #[inline(always)]
+    #[inline]
     pub fn from_local() -> Result<Self, GDError> {
-        Levels::from_decrypted(decode_levels_to_string()?)
+        Self::from_decrypted(&decode_levels_to_string()?)
     }
 
     /// Parses raw savefile string into this struct
-    pub fn from_decrypted(s: String) -> Result<Self, GDError> {
+    pub fn from_decrypted(s: &str) -> Result<Self, GDError> {
         let xmltree = match Value::from_reader_xml(Cursor::new(proper_plist_tags(s).as_bytes())) {
             Ok(v) => v.into_dictionary().unwrap(),
             Err(e) => return Err(GDError::BadPlist(e)),
@@ -102,7 +103,7 @@ impl Levels {
             })
             .collect::<Vec<Level>>();
 
-        let levels = Levels {
+        let levels = Self {
             levels: levels_parsed, // one of these might be for lists. will consider that later
             headers: LevelsFileHeaders {
                 llm02: llm_02,
@@ -141,14 +142,14 @@ impl Levels {
     /// Exports this struct as encrypted XML to CCLocalLevels.dat
     pub fn export_to_savefile(&mut self) -> Result<(), GDError> {
         let savefile = get_local_levels_path().unwrap();
-        let export_str = encrypt_savefile_str(self.export_to_string());
+        let export_str = encrypt_savefile_str(&self.export_to_string());
         write(savefile, export_str)?;
         Ok(())
     }
 
     /// Exports this struct as encrypted XML to a given file
     pub fn export_to_file(&mut self, file: PathBuf) -> Result<(), GDError> {
-        let export_str = encrypt_savefile_str(self.export_to_string());
+        let export_str = encrypt_savefile_str(&self.export_to_string());
         write(file, export_str)?;
         Ok(())
     }
@@ -159,13 +160,13 @@ impl Levels {
         let backup_path = format!("{}.bak", savefile.to_string_lossy());
         write(backup_path, read(&savefile)?)?;
 
-        let export_str = encrypt_savefile_str(self.export_to_string());
+        let export_str = encrypt_savefile_str(&self.export_to_string());
         write(savefile, export_str)?;
         Ok(())
     }
 }
 
-#[inline(always)]
+#[inline]
 fn vec_as_str(data: &[u8]) -> String {
     String::from_utf8(data.to_vec()).unwrap()
 }
@@ -206,7 +207,7 @@ impl Level {
         description: Option<T>,
         song: Option<i64>,
     ) -> Self {
-        Level {
+        Self {
             title: Some(title.into()),
             author: Some(author.into()),
             description: description.map(|desc| b64_encode(desc.into().as_bytes().to_vec())),
@@ -215,11 +216,12 @@ impl Level {
                 objects: vec![],
             })),
             song,
-            properties: Level::default_properties(),
+            properties: Self::default_properties(),
         }
     }
 
     /// Generates a hashmap with default level perties
+    #[must_use]
     pub fn default_properties() -> HashMap<String, Value> {
         let mut ki6_dict = Dictionary::new();
         for i in 0..15 {
@@ -253,13 +255,13 @@ impl Level {
 
     /// Parses a .gmd file to a `Level` object
     pub fn from_gmd<T: Into<PathBuf>>(path: T) -> Result<Self, GDError> {
-        let file = proper_plist_tags(vec_as_str(&fs::read(path.into())?));
+        let file = proper_plist_tags(&fs::read_to_string(path.into())?);
         let xmltree = Value::from_reader_xml(Cursor::new(file.as_bytes()))?
             .as_dictionary_mut()
             .unwrap()
             .clone();
 
-        Ok(Level::from_dict(xmltree))
+        Ok(Self::from_dict(xmltree))
     }
 
     /// Exports the level to a .gmd file
@@ -274,7 +276,7 @@ impl Level {
     }
 
     /// Parses a `plist::Dictionary` into a Level object
-    pub(crate) fn from_dict(d: Dictionary) -> Self {
+    pub(crate) fn from_dict(dictionary: Dictionary) -> Self {
         // level data kv pairs
         // k2: level name
         // k3: description
@@ -291,7 +293,7 @@ impl Level {
         // residual properties
         let mut properties: HashMap<String, Value> = HashMap::new();
 
-        for (property, value) in d.into_iter() {
+        for (property, value) in dictionary {
             match property.as_str() {
                 "k2" => title = Some(value.as_string().unwrap().to_owned()),
                 "k3" => description = Some(value.as_string().unwrap().to_owned()),
@@ -304,16 +306,13 @@ impl Level {
             }
         }
 
-        let mut level_data: Option<LevelState> = None;
-        if let Some(d) = data {
-            level_data = Some(LevelState::Encrypted(EncryptedLevelData { data: d }))
-        }
+        let data = data.map(|data| LevelState::Encrypted(EncryptedLevelData { data }));
 
-        Level {
+        Self {
             title,
             author,
             description,
-            data: level_data,
+            data,
             song,
             properties,
         }
@@ -324,7 +323,7 @@ impl Level {
     pub fn decrypt_level_data(&mut self) {
         let raw_data = match &self.data {
             Some(data) => match data {
-                LevelState::Encrypted(encrypted) => encrypted.data.clone(),
+                LevelState::Encrypted(encrypted) => &encrypted.data,
                 LevelState::Decrypted(_) => return, // already decrypted
             },
             None => return, // no level data
@@ -334,11 +333,12 @@ impl Level {
     }
 
     /// Returns the decrypted level data as a `LevelData` object if there is data.
+    #[must_use]
     pub fn get_decrypted_data(&self) -> Option<LevelData> {
-        let raw_data = match self.data.clone() {
+        let raw_data = match &self.data {
             Some(data) => match data {
-                LevelState::Encrypted(encrypted) => encrypted.data.clone(),
-                LevelState::Decrypted(d) => return Some(d), // already decrypted
+                LevelState::Encrypted(encrypted) => &encrypted.data,
+                LevelState::Decrypted(d) => return Some(d.clone()), // already decrypted
             },
             None => return None, // no level data
         };
@@ -362,44 +362,53 @@ impl Level {
     }
 
     /// Returns this object as a `plist::Dictionary`
+    #[must_use]
     pub fn to_dict(&self) -> Dictionary {
         let mut properties = Dictionary::new();
+
         if let Some(v) = self.title.clone() {
             properties.insert("k2".to_string(), Value::from(v));
-        };
+        }
+
         if let Some(v) = self.description.clone() {
             properties.insert("k3".to_string(), Value::from(v));
-        };
+        }
+
         if let Some(v) = self.data.clone() {
             let str = match v {
                 LevelState::Decrypted(data) => data.serialise_to_string(),
                 LevelState::Encrypted(data) => data.data,
             };
+
             properties.insert("k4".to_string(), Value::from(str));
-        };
+        }
+
         if let Some(v) = self.author.clone() {
             properties.insert("k5".to_string(), Value::from(v));
-        };
+        }
+
         if let Some(v) = self.song {
             properties.insert("k45".to_string(), Value::from(v));
-        };
+        }
 
-        for (p, val) in self.properties.clone().into_iter() {
+        for (p, val) in self.properties.clone() {
             properties.insert(p, val);
         }
 
         properties
     }
 
-    /// Adds a GDObject to `self.objects`
+    /// Adds a [`GDObject`] to `self.objects`
     pub fn add_object(&mut self, object: GDObject) {
-        if let Some(data) = &mut self.data {
-            match data {
-                LevelState::Decrypted(state) => {
-                    state.objects.push(object);
-                }
-                LevelState::Encrypted(_) => (),
-            };
+        let Some(data) = &mut self.data else {
+            return;
+        };
+
+        match data {
+            LevelState::Decrypted(state) => {
+                state.objects.push(object);
+            }
+            LevelState::Encrypted(_) => (),
         }
     }
 }
@@ -417,17 +426,13 @@ impl Display for Level {
         write!(
             f,
             "\"{}\" ({}) by {} using song {}; {info_str}",
-            self.title.clone().unwrap_or("<No title>".to_string()),
+            self.title.as_deref().unwrap_or("<No title>"),
             vec_as_str(&b64_decode(
                 self.description
-                    .clone()
-                    .unwrap_or("PE5vIGRlc2NyaXB0aW9uPg==".to_string())
-                    .as_bytes()
-                    .to_vec()
+                    .as_deref()
+                    .unwrap_or("PE5vIGRlc2NyaXB0aW9uPg==")
             )),
-            self.author
-                .clone()
-                .unwrap_or("<Unknown author>".to_string()),
+            self.author.as_deref().unwrap_or("<Unknown author>"),
             self.song.unwrap_or(0)
         )
     }
@@ -435,18 +440,19 @@ impl Display for Level {
 
 impl LevelData {
     /// Serialises this object to a string by serialising each subsequent component.
+    #[must_use]
     pub fn serialise_to_string(&self) -> String {
         let objstr = self
             .objects
             .iter()
-            .map(|obj| obj.serialise_to_string())
-            .collect::<Vec<String>>()
-            .join("");
+            .map(GDObject::serialise_to_string)
+            .collect::<String>();
         let unencrypted = format!("{};{objstr}", self.headers.clone());
-        vec_as_str(&encrypt_level_str(unencrypted))
+        vec_as_str(&encrypt_level_str(&unencrypted))
     }
 
     /// Returns a list of all the groups that contain at least one object
+    #[must_use]
     pub fn get_used_groups(&self) -> Vec<Group> {
         if self.objects.is_empty() {
             return vec![];
@@ -454,9 +460,10 @@ impl LevelData {
 
         let mut groups = HashSet::new();
 
-        for object in self.objects.iter() {
+        for object in &self.objects {
             groups.extend(object.config.groups.iter());
         }
+
         let mut arr: Vec<Group> = groups.into_iter().collect();
         arr.sort();
         arr
@@ -467,10 +474,11 @@ impl LevelData {
         let all: BTreeSet<Group> = (1..10000).map(Group::Regular).collect();
         let used: BTreeSet<Group> = self.get_used_groups().into_iter().collect();
 
-        all.difference(&used).cloned().collect::<Vec<Group>>()
+        all.difference(&used).copied().collect::<Vec<Group>>()
     }
 
     /// Returns a list of all groups used as arguments in triggers
+    #[must_use]
     pub fn get_argument_groups(&self) -> Vec<i16> {
         if self.objects.is_empty() {
             return vec![];
@@ -491,8 +499,8 @@ impl LevelData {
 
         let mut groups = Vec::with_capacity(self.objects.len());
 
-        for object in self.objects.iter() {
-            for p in group_properties.iter() {
+        for object in &self.objects {
+            for p in &group_properties {
                 if let Some(val) = object.get_property(*p) {
                     match val {
                         crate::gdobj::GDValue::Group(g) => groups.push(g),
@@ -503,27 +511,31 @@ impl LevelData {
             }
         }
 
-        groups.sort();
+        groups.sort_unstable();
         groups.dedup();
         groups
     }
 
     /// Parse raw level data to this struct
-    pub fn parse(raw_data: String) -> Self {
+    #[must_use]
+    pub fn parse(raw_data: &str) -> Self {
         // parse level data
         let raw_data = decompress(raw_data.as_bytes().to_vec()).unwrap();
-        let decrypted = std::str::from_utf8(&raw_data[..]).unwrap();
-        let split = decrypted.split(";").collect::<Vec<&str>>();
+        let decrypted = from_utf8(&raw_data[..]).unwrap();
+        let mut split = decrypted.split(';').collect::<Vec<&str>>();
 
-        let headers = split[0].to_string();
-        let mut objects = Vec::with_capacity(split.len() - 1);
+        let headers = split.remove(0);
+        let mut objects = Vec::with_capacity(split.len());
 
-        for object in &split[1..] {
+        for object in split {
             if object.len() > 1 {
                 objects.push(GDObject::parse_str(object));
             }
         }
 
-        LevelData { headers, objects }
+        Self {
+            headers: headers.to_owned(),
+            objects,
+        }
     }
 }

--- a/src/gdobj/defaults.rs
+++ b/src/gdobj/defaults.rs
@@ -56,7 +56,8 @@ use super::GDObject;
  */
 
 /// Maps object IDs to their default GD object strings (as the editor would produce them).  
-/// Sourced from HDanke's [default object strings](https://github.com/UHDanke/gmdkit/blob/main/src/gmdkit/defaults/objects.py)
+///
+/// Sourced from HDanke's [default object strings](https://github.com/UHDanke/gmdkit/blob/main/src/gmdkit/defaults/objects.py).
 /// This map only stores the unique object strings that are not shared
 pub static OBJECT_DEFAULTS_UNIQUE: Map<i32, &'static str> = phf_map! {
     29i32 => "1,29,2,0,3,0,36,1,7,255,8,255,9,255,10,0.5,35,1,23,1000;",
@@ -125,31 +126,38 @@ pub static OBJECT_DEFAULTS_UNIQUE: Map<i32, &'static str> = phf_map! {
 
 /// Returns the default [`GDObject`] for the given object ID.
 /// If the ID has a known entry in [`OBJECT_DEFAULTS`], it is parsed from that string
+#[must_use]
 pub fn default_object(id: i32) -> GDObject {
-    match OBJECT_DEFAULTS_UNIQUE.get(&id) {
-        Some(s) => GDObject::parse_str(s),
-        None => match check_common_suffix(id) {
-            Some(suf) => GDObject::parse_str(&format!("1,{id}{suf}")),
-            None => GDObject::new(id, &GDObjConfig::default(), vec![]),
-        },
+    if let Some(s) = OBJECT_DEFAULTS_UNIQUE.get(&id) {
+        return GDObject::parse_str(s);
     }
+
+    if let Some(suf) = check_common_suffix(id) {
+        return GDObject::parse_str(&format!("1,{id}{suf}"));
+    }
+
+    GDObject::new(id, &GDObjConfig::default(), vec![])
 }
 
 /// Returns the raw object string of a default object by ID.
+#[must_use]
 pub fn default_object_string(id: i32) -> String {
-    match OBJECT_DEFAULTS_UNIQUE.get(&id) {
-        Some(s) => s.to_string(),
-        None => match check_common_suffix(id) {
-            Some(suf) => format!("1,{id}{suf}"),
-            // unknown id defaults to minimal needed properties
-            None => format!("1,{id},2,0,3,0;"),
-        },
+    if let Some(s) = OBJECT_DEFAULTS_UNIQUE.get(&id).copied() {
+        return s.to_owned();
     }
+
+    if let Some(suf) = check_common_suffix(id) {
+        return format!("1,{id}{suf}");
+    }
+
+    // unknown id defaults to minimal needed properties
+    format!("1,{id},2,0,3,0;")
 }
 
 /// Returns a common suffix if a default object ID uses it.
 /// Example: IDs 1 through 9 all end with `,2,0,3,0;`
-pub fn check_common_suffix(id: i32) -> Option<&'static str> {
+#[must_use]
+pub const fn check_common_suffix(id: i32) -> Option<&'static str> {
     // this match statement is particularly messy, so line breaks are forced through comments
     // otherwise, rustfmt makes skyscrapers out of the match arms
     match id {

--- a/src/gdobj/lookup.rs
+++ b/src/gdobj/lookup.rs
@@ -245,6 +245,7 @@ pub static PROPERTY_TABLE: Map<u16, (&'static str, GDObjPropType)> = phf_map! {
 };
 
 /// Get type of a property by ID
+#[must_use]
 pub fn get_property_type(p: u16) -> Option<GDObjPropType> {
     PROPERTY_TABLE.get(&p).map(|v| v.1)
 }

--- a/src/gdobj/misc.rs
+++ b/src/gdobj/misc.rs
@@ -14,7 +14,8 @@ use crate::gdobj::{
 /// Returns a default block object.
 /// # Arguments
 /// `config`: Object config
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn default_block(config: &GDObjConfig) -> GDObject {
     GDObject::new(DEFAULT_BLOCK, config, vec![])
 }

--- a/src/gdobj/mod.rs
+++ b/src/gdobj/mod.rs
@@ -1,6 +1,7 @@
-//! This module contains the GDObject struct, used for parsing to/from raw object strings
-//! This module also contains the GDObjConfig struct for creating new GDObjects
+//! This module contains the [`GDObject`] struct, used for parsing to/from raw object strings
+//! This module also contains the [`GDObjConfig`] struct for creating new [`GDObject`]s
 use std::{
+    cmp::Ordering,
     fmt::{Debug, Display, Write},
     str::FromStr,
 };
@@ -38,7 +39,7 @@ pub mod animation_ids {
 
     /// Animations for the big beast (chomper)
     #[repr(i32)]
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub enum BigBeast {
         Bite = 0,
         Attack01 = 1,
@@ -48,7 +49,7 @@ pub mod animation_ids {
 
     /// Animations for the bat
     #[repr(i32)]
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub enum Bat {
         Idle01 = 0,
         Idle02 = 1,
@@ -64,7 +65,7 @@ pub mod animation_ids {
 
     /// Animations for the spike ball
     #[repr(i32)]
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
     pub enum Spikeball {
         Idle01 = 0,
         Idle02 = 1,
@@ -78,7 +79,7 @@ pub mod animation_ids {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 /// Enum for animation IDs
 pub enum Anim {
     /// User-specified animation
@@ -92,11 +93,11 @@ pub enum Anim {
 }
 
 impl From<Anim> for i32 {
-    fn from(value: Anim) -> i32 {
+    fn from(value: Anim) -> Self {
         match value {
-            Anim::Bat(b) => b as i32,
-            Anim::BigBeast(b) => b as i32,
-            Anim::Spikeball(s) => s as i32,
+            Anim::Bat(b) => b as Self,
+            Anim::BigBeast(b) => b as Self,
+            Anim::Spikeball(s) => s as Self,
             Anim::Other(i) => i,
         }
     }
@@ -115,7 +116,8 @@ pub enum Item {
 
 impl Item {
     /// Returns this item's type
-    pub fn get_type(&self) -> ItemType {
+    #[must_use]
+    pub const fn get_type(&self) -> ItemType {
         match self {
             Self::Attempts => ItemType::Attempts,
             Self::Counter(_) => ItemType::Counter,
@@ -124,13 +126,17 @@ impl Item {
             Self::Timer(_) => ItemType::Timer,
         }
     }
-    #[inline(always)]
+
     /// Returns this item's type as an i32
-    pub fn get_type_as_i32(&self) -> i32 {
+    #[inline]
+    #[must_use]
+    pub const fn get_type_as_i32(&self) -> i32 {
         self.get_type() as i32
     }
+
     /// Returns this item's special mode if it has one
-    pub fn as_special_mode(&self) -> Option<CounterMode> {
+    #[must_use]
+    pub const fn as_special_mode(&self) -> Option<CounterMode> {
         match self {
             Self::Attempts => Some(CounterMode::Attempts),
             Self::MainTime => Some(CounterMode::MainTime),
@@ -138,14 +144,17 @@ impl Item {
             _ => None,
         }
     }
-    #[inline(always)]
+
     /// Returns this item's special mode if it has one as an i32
-    pub fn as_special_mode_i32(&self) -> i32 {
+    #[inline]
+    #[must_use]
+    pub const fn as_special_mode_i32(&self) -> i32 {
         self.as_special_mode().unwrap() as i32
     }
 
     /// Returns this item's ID
-    pub fn id(&self) -> i16 {
+    #[must_use]
+    pub const fn id(&self) -> i16 {
         match self {
             Self::Counter(c) => *c,
             Self::Timer(t) => *t,
@@ -357,7 +366,7 @@ pub enum GDValue {
     Group(i16),
     /// Any item ID, whcih is represented by an `i16`.
     Item(i16),
-    /// A list of group IDs as i16, which is stored in a SmallVec.
+    /// A list of group IDs as i16, which is stored in a [`SmallVec`].
     GroupList(smallvec::SmallVec<[i16; LIST_ALLOCSIZE]>),
     /// A list of probability pairs: (group id, relative chance). Used in the advanced random trigger
     ProbabilitiesList(smallvec::SmallVec<[(i16, i32); LIST_ALLOCSIZE]>),
@@ -376,7 +385,7 @@ pub enum GDValue {
 }
 
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(missing_docs)]
 /// Enum for all events that the event trigger can listen for
 pub enum Event {
@@ -463,7 +472,7 @@ pub enum Event {
 }
 
 impl From<i32> for Event {
-    /// Converts the event ID to the variant of the [`Event`] enum. Default to TinyLanding.
+    /// Converts the event ID to the variant of the [`Event`] enum.
     fn from(i: i32) -> Self {
         match i {
             1 => Self::TinyLanding,
@@ -584,23 +593,22 @@ where
     let mut idx = 0;
     let mut tuples = vec![];
     s.split('.').for_each(|c| {
-        match idx % 2 == 0 {
-            true => {
-                // at even idx, so this is a group
-                curr_group = parse!(c => T)
-            }
-            false => {
-                // at odd idx, so this is a chance
-                tuples.push((curr_group, parse!(c => S)));
-            }
-        };
-        idx += 1
+        if idx % 2 == 0 {
+            // at even idx, so this is a group
+            curr_group = parse!(c => T);
+        } else {
+            // at odd idx, so this is a chance
+            tuples.push((curr_group, parse!(c => S)));
+        }
+
+        idx += 1;
     });
     tuples
 }
 
 impl GDValue {
     /// Converts input string to a variant of this enum based on the property type
+    #[must_use]
     pub fn from(t: GDObjPropType, s: &str) -> Self {
         match t {
             GDObjPropType::Bool => Self::Bool(s == "1"),
@@ -630,15 +638,16 @@ impl GDValue {
         }
     }
 
-    #[inline(always)]
     /// Converts a vector of [`Group`]s to a [`GDValue`]
-    pub fn from_group_list(g: Vec<Group>) -> Self {
+    #[inline]
+    #[must_use]
+    pub fn from_group_list(g: &[Group]) -> Self {
         Self::GroupList(SmallVec::from_vec(g.iter().map(|&g| g.id()).collect()))
     }
 
-    #[inline(always)]
     /// Converts a vector of parent [`Group`]s to a [`GDValue`]
-    pub fn parents_group_list(g: Vec<Group>) -> Self {
+    #[must_use]
+    pub fn parents_group_list(g: &[Group]) -> Self {
         Self::GroupList(SmallVec::from_vec(
             g.iter()
                 .filter_map(|g| match g {
@@ -649,26 +658,30 @@ impl GDValue {
         ))
     }
 
-    #[inline(always)]
     /// Converts a probabilities list to a [`GDValue`].
+    #[inline]
+    #[must_use]
     pub fn from_prob_list(g: Vec<(i16, i32)>) -> Self {
         Self::ProbabilitiesList(SmallVec::from_vec(g))
     }
 
-    #[inline(always)]
     /// Converts a spawn remaps list to a [`GDValue`].
+    #[inline]
+    #[must_use]
     pub fn from_spawn_remaps(g: Vec<(i16, i16)>) -> Self {
         Self::SpawnRemapsList(SmallVec::from_vec(g))
     }
 
-    #[inline(always)]
     /// Converts a raw colour channel value to a [`GDValue`].
+    #[inline]
+    #[must_use]
     pub fn colour_channel(s: &str) -> Self {
         Self::ColourChannel(ColourChannel::from(s.parse().unwrap_or(0)))
     }
 
-    #[inline(always)]
     /// Converts a raw zlayer value to a [`GDValue`].
+    #[inline]
+    #[must_use]
     pub fn zlayer(s: &str) -> Self {
         Self::ZLayer(ZLayer::from(s.parse().unwrap_or(0)))
     }
@@ -682,6 +695,7 @@ macro_rules! fmt_intlist {
             if idx != 0 {
                 items_str.push('.');
             }
+            #[allow(clippy::cast_lossless)]
             items_str.push_str($i_buf.format(*item as i32));
         }
         items_str
@@ -711,8 +725,8 @@ impl Display for GDValue {
         let mut d_buf = dtoa::Buffer::new();
 
         match self {
-            GDValue::Bool(b) => write!(f, "{}", if *b { '1' } else { '0' }),
-            GDValue::Toggle(b) => write!(
+            Self::Bool(b) => write!(f, "{}", if *b { '1' } else { '0' }),
+            Self::Toggle(b) => write!(
                 f,
                 "{}",
                 match b {
@@ -720,18 +734,18 @@ impl Display for GDValue {
                     false => "-1",
                 }
             ),
-            GDValue::ColourChannel(v) => write!(f, "{}", i_buf.format(Into::<i16>::into(*v))),
-            GDValue::Easing(v) => write!(f, "{}", i_buf.format(*v as i32)),
-            GDValue::Float(v) => write!(f, "{}", d_buf.format(*v)),
-            GDValue::Group(v) | GDValue::Item(v) => write!(f, "{}", i_buf.format(*v)),
-            GDValue::GroupList(v) => write!(f, "{}", fmt_intlist!(v, i_buf)),
-            GDValue::ProbabilitiesList(v) => write!(f, "{}", fmt_inttuples!(v, i_buf)),
-            GDValue::SpawnRemapsList(v) => write!(f, "{}", fmt_inttuples!(v, i_buf)),
-            GDValue::Int(v) => write!(f, "{}", i_buf.format(*v)),
-            GDValue::Short(v) => write!(f, "{}", i_buf.format(*v)),
-            GDValue::String(v) => write!(f, "{v}"),
-            GDValue::ZLayer(v) => write!(f, "{}", i_buf.format(*v as i32)),
-            GDValue::Events(evts) => write!(f, "{}", fmt_intlist!(evts, i_buf)),
+            Self::ColourChannel(v) => write!(f, "{}", i_buf.format(Into::<i16>::into(*v))),
+            Self::Easing(v) => write!(f, "{}", i_buf.format(*v as i32)),
+            Self::Float(v) => write!(f, "{}", d_buf.format(*v)),
+            Self::Group(v) | Self::Item(v) => write!(f, "{}", i_buf.format(*v)),
+            Self::GroupList(v) => write!(f, "{}", fmt_intlist!(v, i_buf)),
+            Self::ProbabilitiesList(v) => write!(f, "{}", fmt_inttuples!(v, i_buf)),
+            Self::SpawnRemapsList(v) => write!(f, "{}", fmt_inttuples!(v, i_buf)),
+            Self::Int(v) => write!(f, "{}", i_buf.format(*v)),
+            Self::Short(v) => write!(f, "{}", i_buf.format(*v)),
+            Self::String(v) => write!(f, "{v}"),
+            Self::ZLayer(v) => write!(f, "{}", i_buf.format(*v as i32)),
+            Self::Events(evts) => write!(f, "{}", fmt_intlist!(evts, i_buf)),
         }
     }
 }
@@ -878,8 +892,10 @@ pub struct GDObject {
 
 impl Display for GDObject {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let group_str = match !self.config.groups.is_empty() {
-            true => &format!(
+        let group_str = if self.config.groups.is_empty() {
+            ""
+        } else {
+            &format!(
                 " with groups: {}",
                 self.config
                     .groups
@@ -887,19 +903,18 @@ impl Display for GDObject {
                     .map(|g| format!("{}", g.id()))
                     .collect::<Vec<String>>()
                     .join(", ")
-            ),
-            false => "",
+            )
         };
 
         let mut trigger_conf_str = String::new();
         if self.config.trigger_cfg.spawnable || self.config.trigger_cfg.touchable {
             if self.config.trigger_cfg.multitriggerable {
-                trigger_conf_str += "Multi"
+                trigger_conf_str += "Multi";
             }
             if self.config.trigger_cfg.touchable {
-                trigger_conf_str += "touchable "
+                trigger_conf_str += "touchable ";
             } else if self.config.trigger_cfg.spawnable {
-                trigger_conf_str += "spawnable "
+                trigger_conf_str += "spawnable ";
             }
         }
 
@@ -921,7 +936,7 @@ impl Debug for GDObject {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut property_str = String::with_capacity(self.properties.len() * 32);
 
-        for (property, value) in self.properties.iter() {
+        for (property, value) in &self.properties {
             let desc = lookup::PROPERTY_TABLE.get(property).map(|p| p.0);
             if let Some(d) = desc {
                 write!(property_str, "\n    - {d}: {value:?}")
@@ -940,22 +955,22 @@ impl Debug for GDObject {
 }
 
 impl GDObject {
-    /// Parses raw object string to GDObject
-    pub fn parse_str(s: &str) -> GDObject {
-        let mut obj = GDObject {
+    /// Parses raw object string to [`GDObject`]
+    pub fn parse_str(s: &str) -> Self {
+        let mut obj = Self {
             id: 1,
             config: GDObjConfig::default(),
             properties: vec![],
         };
 
-        let mut iter = s.trim_end_matches(';').split(",");
+        let mut iter = s.trim_end_matches(';').split(',');
         while let (Some(idx), Some(val)) = (iter.next(), iter.next()) {
-            let idx_u16 = match idx.parse::<u16>() {
-                Ok(n) => n,
-                Err(_) => match idx[2..].parse::<u16>() {
-                    Ok(n) => n + 10_000,
-                    Err(_) => 65535,
-                },
+            let idx_u16 = if let Ok(n) = idx.parse::<u16>() {
+                n
+            } else if let Ok(n) = idx[2..].parse::<u16>() {
+                n + 10_000
+            } else {
+                65535
             };
 
             match idx_u16 {
@@ -969,7 +984,7 @@ impl GDObject {
                 GROUPS => {
                     obj.config.add_groups(
                         val.trim_matches('"')
-                            .split(".")
+                            .split('.')
                             .filter_map(|g| g.parse::<i16>().ok())
                             .map(Group::Regular)
                             .collect::<Vec<Group>>(),
@@ -980,10 +995,10 @@ impl GDObject {
                 EDITOR_LAYER_1 => obj.config.editor_layers.0 = parse!(val => i16),
                 EDITOR_LAYER_2 => obj.config.editor_layers.1 = parse!(val => i16),
                 OBJECT_COLOUR => {
-                    obj.config.colour_channels.0 = ColourChannel::from(parse!(val => i16))
+                    obj.config.colour_channels.0 = ColourChannel::from(parse!(val => i16));
                 }
                 SECONDARY_COLOUR => {
-                    obj.config.colour_channels.1 = ColourChannel::from(parse!(val => i16))
+                    obj.config.colour_channels.1 = ColourChannel::from(parse!(val => i16));
                 }
                 Z_LAYER => obj.config.z_layer = ZLayer::from(parse!(val => i32)),
                 Z_ORDER => obj.config.z_order = parse!(val => i32),
@@ -1090,7 +1105,7 @@ impl GDObject {
                     // add groups method handles deduping
                     obj.config.add_groups(
                         val.trim_matches('"')
-                            .split(".")
+                            .split('.')
                             .filter_map(|g| g.parse::<i16>().ok())
                             .map(Group::Parent)
                             .collect::<Vec<Group>>(),
@@ -1131,9 +1146,10 @@ impl GDObject {
     }
 
     /// Returns this object as a property string
+    #[must_use]
     pub fn serialise_to_string(&self) -> String {
         let mut properties_string = String::with_capacity(self.properties.len() * 8);
-        for (idx, val) in self.properties.iter() {
+        for (idx, val) in &self.properties {
             let (pref, id) = if *idx < 10_000 {
                 ("", *idx)
             } else {
@@ -1145,41 +1161,49 @@ impl GDObject {
         let config_str = self.config.serialise_to_string();
 
         let raw_str = format!("1,{}{config_str}{properties_string}", self.id);
-        raw_str.replace("\"", "") + ";"
+        raw_str.replace('"', "") + ";"
     }
 
     /// Returns this object's name
+    #[must_use]
     pub fn get_name(&self) -> String {
         OBJECT_NAMES
             .iter()
-            .find(|&o| o.0 == self.id)
-            .unwrap_or(&(0, format!("Object {}", self.id).as_str()))
-            .1
-            .to_string()
+            .find_map(|(id, name)| {
+                if *id == self.id {
+                    Some((*name).to_owned())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_else(|| format!("Object {}", self.id))
     }
 
-    /// Creates a new GDObject from ID, config, and extra proerties
-    #[inline(always)]
+    /// Creates a new [`GDObject`] from ID, config, and extra proerties
+    #[inline]
+    #[must_use]
     pub fn new(id: i32, config: &GDObjConfig, properties: Vec<(u16, GDValue)>) -> Self {
-        GDObject {
+        Self {
             id,
             config: config.clone(),
             properties,
         }
     }
 
-    #[inline]
     /// Creates a default object from the specified ID
+    #[inline]
+    #[must_use]
     pub fn default_from_id(id: i32) -> Self {
         defaults::default_object(id)
     }
 
-    #[inline(always)]
-    fn get_attr_as_gdvalue(&self, attr: GDObjAttributes) -> GDValue {
+    #[inline]
+    const fn get_attr_as_gdvalue(&self, attr: GDObjAttributes) -> GDValue {
         GDValue::Bool(self.config.get_attribute_flag(attr))
     }
 
     /// Fetches a property from this object's configuration
+    #[must_use]
     pub fn get_property(&self, p: u16) -> Option<GDValue> {
         match p {
             // one of the most fascinating matches of all time
@@ -1188,7 +1212,7 @@ impl GDObject {
             3 => Some(GDValue::Float(self.config.pos.1)),
             6 => Some(GDValue::Float(self.config.angle)),
             11 => Some(GDValue::Bool(self.config.trigger_cfg.touchable)),
-            57 => Some(GDValue::from_group_list(self.config.groups.clone())),
+            57 => Some(GDValue::from_group_list(&self.config.groups)),
             62 => Some(GDValue::Bool(self.config.trigger_cfg.spawnable)),
             87 => Some(GDValue::Bool(self.config.trigger_cfg.multitriggerable)),
             128 => Some(GDValue::Float(self.config.scale.0)),
@@ -1242,7 +1266,7 @@ impl GDObject {
 }
 
 /// Trigger config, used for defining general properties of a trigger object
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TriggerConfig {
     /// is touch triggerable?
     pub touchable: bool,
@@ -1261,62 +1285,47 @@ pub enum Group {
 }
 
 impl Ord for Group {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> Ordering {
         // check ids first
         // check the types only if equal
         match self.id().cmp(&other.id()) {
-            std::cmp::Ordering::Equal => self.get_type().cmp(&other.get_type()),
+            Ordering::Equal => self.get_type().cmp(&other.get_type()),
             o => o,
         }
     }
 }
 
 impl PartialOrd for Group {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(missing_docs)]
 /// Group type enum
 pub enum GroupType {
-    Regular,
     Parent,
-}
-
-impl Ord for GroupType {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        if self == other {
-            std::cmp::Ordering::Equal
-        } else if *self == Self::Regular {
-            // other is parent, so is less
-            std::cmp::Ordering::Greater
-        } else {
-            std::cmp::Ordering::Less
-        }
-    }
-}
-
-impl PartialOrd for GroupType {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
+    #[default]
+    Regular,
 }
 
 impl Group {
     /// Returns this group's ID
-    pub fn id(&self) -> i16 {
+    #[must_use]
+    pub const fn id(&self) -> i16 {
         match self {
             Self::Regular(id) => *id,
             Self::Parent(id) => *id,
         }
     }
+
     /// Returns this group's type
-    pub fn get_type(&self) -> GroupType {
+    #[must_use]
+    pub const fn get_type(&self) -> GroupType {
         match self {
-            Group::Parent(_) => GroupType::Parent,
-            Group::Regular(_) => GroupType::Regular,
+            Self::Parent(_) => GroupType::Parent,
+            Self::Regular(_) => GroupType::Regular,
         }
     }
 }
@@ -1360,7 +1369,7 @@ pub struct GDObjConfig {
 
 impl Default for GDObjConfig {
     fn default() -> Self {
-        GDObjConfig {
+        Self {
             pos: (0.0, 0.0),
             scale: (1.0, 1.0),
             angle: 0.0,
@@ -1384,12 +1393,14 @@ impl Default for GDObjConfig {
 
 impl GDObjConfig {
     /// Alias for default
-    #[inline(always)]
+    #[inline]
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Serialises this config struct to a string
+    #[must_use]
     pub fn serialise_to_string(&self) -> String {
         let mut properties = String::with_capacity(64);
         let _ = write!(
@@ -1450,7 +1461,7 @@ impl GDObjConfig {
                 .collect::<Vec<String>>()
                 .join(".");
             properties.push_str(group_str);
-        };
+        }
 
         properties
     }
@@ -1462,175 +1473,228 @@ impl GDObjConfig {
     }
 
     /// Sets groups of this object
-    #[inline(always)]
+    #[inline]
+    #[must_use]
     pub fn groups<T: IntoIterator<Item = I>, I: Into<Group>>(mut self, groups: T) -> Self {
-        self.groups = groups.into_iter().map(|g| g.into()).collect();
+        self.groups = groups.into_iter().map(Into::into).collect();
         self.dedup_groups();
         self
     }
+
     /// Adds groups to this object's groups
-    #[inline(always)]
+    #[inline]
     pub fn add_groups<T: AsRef<[Group]>>(&mut self, groups: T) {
         self.groups.extend_from_slice(groups.as_ref());
         self.dedup_groups();
     }
+
     /// Adds group to this object's groups
-    #[inline(always)]
+    #[inline]
     pub fn add_group(&mut self, group: Group) {
         self.groups.push(group);
         self.dedup_groups();
     }
+
     /// Removes this group from this object's groups
-    #[inline(always)]
+    #[inline]
     pub fn remove_group(&mut self, group: Group) {
         if let Some(idx) = self.groups.iter().position(|&g| g == group) {
             self.groups.swap_remove(idx);
         }
     }
+
     /// Clears all groups from this object
-    #[inline(always)]
+    #[inline]
     pub fn clear_groups(&mut self) {
         self.groups.clear();
     }
+
     /// Sets x position of this object
-    #[inline(always)]
-    pub fn x(mut self, x: f64) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn x(mut self, x: f64) -> Self {
         self.pos.0 = x;
+
         self
     }
+
     /// Sets y position of this object
-    #[inline(always)]
-    pub fn y(mut self, y: f64) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn y(mut self, y: f64) -> Self {
         self.pos.1 = y;
+
         self
     }
 
     /// Applies a translation to this object's position
-    pub fn translate(mut self, x: f64, y: f64) -> Self {
+    #[must_use]
+    pub const fn translate(mut self, x: f64, y: f64) -> Self {
         self.pos.0 += x;
         self.pos.1 += y;
+
         self
     }
 
     /// Sets x and y position of this object
-    #[inline(always)]
-    pub fn pos(mut self, x: f64, y: f64) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn pos(mut self, x: f64, y: f64) -> Self {
         self.pos = (x, y);
+
         self
     }
+
     /// Sets x scale of this object
-    #[inline(always)]
-    pub fn xscale(mut self, xscale: f64) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn xscale(mut self, xscale: f64) -> Self {
         self.scale.0 = xscale;
+
         self
     }
+
     /// Sets y scale of this object
-    #[inline(always)]
-    pub fn yscale(mut self, yscale: f64) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn yscale(mut self, yscale: f64) -> Self {
         self.scale.1 = yscale;
+
         self
     }
+
     /// Sets x and y scale of this object
-    #[inline(always)]
-    pub fn scale(mut self, x: f64, y: f64) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn scale(mut self, x: f64, y: f64) -> Self {
         self.scale = (x, y);
         self
     }
+
     /// Sets rotation angle of this object
-    #[inline(always)]
-    pub fn angle(mut self, angle: f64) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn angle(mut self, angle: f64) -> Self {
         self.angle = angle;
         self
     }
+
     /// Makes this object touch triggerable
-    #[inline(always)]
-    pub fn touchable(mut self, touchable: bool) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn touchable(mut self, touchable: bool) -> Self {
         self.trigger_cfg.touchable = touchable;
         self
     }
+
     /// Makes this object spawn triggerable
-    #[inline(always)]
-    pub fn spawnable(mut self, spawnable: bool) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn spawnable(mut self, spawnable: bool) -> Self {
         self.trigger_cfg.spawnable = spawnable;
         self
     }
+
     /// Makes this object multi-triggerable
-    #[inline(always)]
-    pub fn multitrigger(mut self, multi: bool) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn multitrigger(mut self, multi: bool) -> Self {
         self.trigger_cfg.multitriggerable = multi;
         self
     }
+
     /// Sets this object's base colour channel
-    #[inline(always)]
-    pub fn set_base_colour(mut self, channel: ColourChannel) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn set_base_colour(mut self, channel: ColourChannel) -> Self {
         self.colour_channels.0 = channel;
         self
     }
+
     /// Sets this object's detail colour channel
-    #[inline(always)]
-    pub fn set_detail_colour(mut self, channel: ColourChannel) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn set_detail_colour(mut self, channel: ColourChannel) -> Self {
         self.colour_channels.1 = channel;
         self
     }
+
     /// Sets this object's Z-layer
-    #[inline(always)]
-    pub fn set_z_layer(mut self, z: ZLayer) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn set_z_layer(mut self, z: ZLayer) -> Self {
         self.z_layer = z;
         self
     }
+
     /// Sets this object's Z-order
-    #[inline(always)]
-    pub fn set_z_order(mut self, z: i32) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn set_z_order(mut self, z: i32) -> Self {
         self.z_order = z;
         self
     }
+
     /// Sets editor layer 1 of this object
-    #[inline(always)]
-    pub fn editor_layer_1(mut self, l: i16) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn editor_layer_1(mut self, l: i16) -> Self {
         self.editor_layers.0 = l;
         self
     }
+
     /// Sets editor layer 2 of this object
-    #[inline(always)]
-    pub fn editor_layer_2(mut self, l: i16) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn editor_layer_2(mut self, l: i16) -> Self {
         self.editor_layers.1 = l;
         self
     }
+
     /// Sets this object's material id
-    #[inline(always)]
-    pub fn set_material_id(mut self, material_id: i16) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn set_material_id(mut self, material_id: i16) -> Self {
         self.material_id = material_id;
         self
     }
+
     /// Sets this object's enter effect channel
-    #[inline(always)]
-    pub fn set_enter_channel(mut self, channel: i16) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn set_enter_channel(mut self, channel: i16) -> Self {
         self.enter_effect_channel = channel;
         self
     }
+
     /// Sets this object's control ID
-    #[inline(always)]
-    pub fn set_control_id(mut self, id: i16) -> Self {
+    #[inline]
+    #[must_use]
+    pub const fn set_control_id(mut self, id: i16) -> Self {
         self.control_id = id;
         self
     }
 
-    /// Gets the value of a set attribute flag.  
+    /// Gets the value of a set attribute flag.
+    ///
     /// The flag is only true if it has been set as such. Unset flags return false.
-    pub fn get_attribute_flag(&self, flag: GDObjAttributes) -> bool {
+    #[must_use]
+    pub const fn get_attribute_flag(&self, flag: GDObjAttributes) -> bool {
         self.attributes.contains(flag)
     }
 
     /// Sets the attribute of the specified flag. Function is useable in builder syntax.
+    #[must_use]
     pub fn set_attribute_flag(mut self, flag: GDObjAttributes, toggle: bool) -> Self {
         self.attributes.set(flag, toggle);
+
         self
     }
 }
 
 bitflags! {
     /// Common attributes container struct
-    #[derive(Debug, Clone, PartialEq, Default, Eq, Hash)]
+    #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
     // #[allow(missing_docs)] won't work here for some odd reason
     pub struct GDObjAttributes: u32 {
         /// @nodoc
@@ -1685,13 +1749,15 @@ bitflags! {
 }
 
 impl GDObjAttributes {
-    #[inline(always)]
+    #[inline]
     /// Makes a default instance of this object
+    #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Serialises this object to a string
+    #[must_use]
     pub fn get_property_str(&self) -> String {
         let fields = [
             (DONT_FADE, Self::dont_fade),
@@ -1719,6 +1785,7 @@ impl GDObjAttributes {
             (CENTER_EFFECT, Self::center_effect),
             (REVERSES_GAMEPLAY, Self::reverse),
         ];
+
         let mut properties_str = String::with_capacity(6 * fields.len());
 
         for (id, flag) in fields {

--- a/src/gdobj/triggers.rs
+++ b/src/gdobj/triggers.rs
@@ -68,7 +68,7 @@ use crate::gdobj::{
 };
 
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(missing_docs)]
 /// Extra ID 2 parameter in the event trigger
 pub enum ExtraID2 {
@@ -79,7 +79,7 @@ pub enum ExtraID2 {
 }
 
 /// Enum for move targets.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(missing_docs)]
 pub enum MoveTarget {
     // Targets this group's parent object
@@ -90,7 +90,7 @@ pub enum MoveTarget {
 
 /// Enum for the GD gamemodes corresponding to their internal values
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(missing_docs)]
 pub enum Gamemode {
     #[default]
@@ -106,7 +106,7 @@ pub enum Gamemode {
 
 /// Enum for stop trigger modes
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(missing_docs)]
 pub enum StopMode {
     Stop = 0,
@@ -116,7 +116,7 @@ pub enum StopMode {
 
 /// Enum for item alignments
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(missing_docs)]
 pub enum ItemAlign {
     Center = 0,
@@ -126,7 +126,7 @@ pub enum ItemAlign {
 
 /// Enum for transition object enter/exit config
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(missing_docs)]
 pub enum TransitionMode {
     Both = 0,
@@ -136,7 +136,7 @@ pub enum TransitionMode {
 
 /// Enum for transition object type (from top, from bottom, etc.)
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(missing_docs)]
 pub enum TransitionType {
     Fade = 22,
@@ -157,7 +157,7 @@ pub enum TransitionType {
 
 /// Enum for item operators
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(missing_docs)]
 pub enum Op {
     Set = 0,
@@ -169,7 +169,7 @@ pub enum Op {
 
 /// Enum for item comparison operators
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(missing_docs)]
 pub enum CompareOp {
     Equals = 0,
@@ -196,9 +196,11 @@ pub struct CompareOperand {
 }
 
 impl CompareOperand {
-    /// Constructor for an operand that is simply a number literal.  
+    /// Constructor for an operand that is simply a number literal.
+    ///
     /// Useful for comparing an [`Item`] against a number
-    pub fn number_literal(num: f64) -> Self {
+    #[must_use]
+    pub const fn number_literal(num: f64) -> Self {
         Self {
             operand_item: Item::Counter(0),
             modifier: num,
@@ -257,7 +259,7 @@ pub enum TargetPlayer {
 }
 
 /// Enum for move mode setting. See structs [`DefaultMove`], [`TargetMove`], and [`DirectionalMove`]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub enum MoveMode {
     /// Normal axis-based move mode
     Default(DefaultMove),
@@ -268,7 +270,7 @@ pub enum MoveMode {
 }
 
 /// Enum for lock config: player or camera
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(missing_docs)]
 pub enum MoveLock {
     Player,
@@ -277,7 +279,7 @@ pub enum MoveLock {
 
 /// Enum for relative UI reference position
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(missing_docs)]
 pub enum UIReferencePos {
     Auto = 1,
@@ -287,7 +289,7 @@ pub enum UIReferencePos {
 }
 
 /// Config struct for default movement
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
 pub struct DefaultMove {
     /// Units to move in x-axis. Used as multiplier of player/camera movement if `x_lock` is used
     pub dx: f64,
@@ -300,7 +302,7 @@ pub struct DefaultMove {
 }
 
 /// Config struct for moving to a specific target.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TargetMove {
     /// Group that will be moved to. Use `POS_PLAYER1` and `POS_PLAYER2` consts to specify moving to one of the players.
     pub target_group_id: MoveTarget,
@@ -312,7 +314,7 @@ pub struct TargetMove {
 
 /// Optional axis lock for move triggers
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum AxisOnlyMove {
     /// Locks to X-axis
     X = 1,
@@ -321,7 +323,7 @@ pub enum AxisOnlyMove {
 }
 
 /// Config struct for moving to a specific target.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DirectionalMove {
     /// Group that will be moved to. Use `POS_PLAYER1` and `POS_PLAYER2` consts to specify moving to one of the players.
     pub target_group_id: MoveTarget,
@@ -333,7 +335,7 @@ pub struct DirectionalMove {
 
 /// Enum for starting speed in a startpos
 #[repr(i32)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(missing_docs)]
 pub enum StartingSpeed {
     X0Point5 = 1,
@@ -374,7 +376,7 @@ impl Display for HSVColour {
 }
 
 /// Enum for target of pulse
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum PulseTarget {
     /// Pulse for a group
     Group(PulseGroup),
@@ -383,14 +385,14 @@ pub enum PulseTarget {
 }
 
 /// Config struct for channel pulses
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PulseChannel {
     /// Channel which is pulsed
     pub channel_id: i16,
 }
 
 /// Config struct for group pulses
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct PulseGroup {
     /// Group that is being pulsed
     pub group_id: i16,
@@ -409,7 +411,7 @@ pub enum PulseMode {
 }
 
 /// RGB colour tuple
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[allow(missing_docs)]
 pub struct Colour {
     pub red: u8,
@@ -417,14 +419,17 @@ pub struct Colour {
     pub blue: u8,
 }
 
+impl From<(u8, u8, u8)> for Colour {
+    fn from((red, green, blue): (u8, u8, u8)) -> Self {
+        Self { red, green, blue }
+    }
+}
+
 impl Colour {
-    /// Converts an RGB tuple to a [`Colour`]
-    pub fn from_rgb(rgb: (u8, u8, u8)) -> Self {
-        Self {
-            red: rgb.0,
-            green: rgb.1,
-            blue: rgb.2,
-        }
+    /// Converts an RGB tuple to a [`Colour`].
+    #[must_use]
+    pub const fn from_rgb((red, green, blue): (u8, u8, u8)) -> Self {
+        Self { red, green, blue }
     }
 
     /// Parses a hex code (#123456) to a [`Colour`]
@@ -548,6 +553,7 @@ pub struct RotationNormal {
 
 impl RotationNormal {
     /// Convert from degrees to this object.
+    #[must_use]
     pub fn from_degrees(deg: f64) -> Self {
         Self {
             degrees: deg % 360.0,
@@ -571,7 +577,7 @@ pub struct RotationAim {
     pub aim_target: i16,
     /// Rotation offset of the rotating group
     pub rot_offset: f64,
-    ///  Overrides aim_target if not None, uses either P1 or P2 as the target instead.
+    ///  Overrides [`Self::aim_target`] if not None, uses either P1 or P2 as the target instead.
     pub player_target: Option<RotationPlayerTarget>,
 }
 
@@ -631,7 +637,8 @@ pub struct ColliderConfig {
 
 impl ColliderConfig {
     /// Creates a new instance of this object from two collision block IDs
-    pub fn two_colliders(collider1_id: i16, collider2_id: i16) -> Self {
+    #[must_use]
+    pub const fn two_colliders(collider1_id: i16, collider2_id: i16) -> Self {
         Self {
             collider1: collider1_id,
             collider2: collider2_id,
@@ -701,6 +708,7 @@ pub enum TouchToggle {
 /// * `silent`: Skips collision checking with the player(s) in the path of its motion. Useful for reducing lag. Collision blocks are unaffected.
 /// * `dynamic`: Updates location of the target group in real time for target/directional move modes.
 /// * `easing`: Optional easing and easing rate (default: 2) tuple.
+#[must_use]
 pub fn move_trigger(
     config: &GDObjConfig,
     move_config: MoveMode,
@@ -763,7 +771,7 @@ pub fn move_trigger(
                 MoveTarget::Player1 => properties.push((CONTROLLING_PLAYER_1, GDValue::Int(1))),
                 MoveTarget::Player2 => properties.push((CONTROLLING_PLAYER_2, GDValue::Int(1))),
                 MoveTarget::Group(id) => properties.push((TARGET_ITEM_2, GDValue::Group(id))),
-            };
+            }
         }
         MoveMode::Directional(config) => {
             if let Some(id) = config.center_group_id {
@@ -774,7 +782,7 @@ pub fn move_trigger(
                 MoveTarget::Player1 => properties.push((CONTROLLING_PLAYER_1, GDValue::Int(1))),
                 MoveTarget::Player2 => properties.push((CONTROLLING_PLAYER_2, GDValue::Int(1))),
                 MoveTarget::Group(id) => properties.push((TARGET_ITEM_2, GDValue::Group(id))),
-            };
+            }
 
             properties.push((DIRECTIONAL_MOVE_MODE, GDValue::Int(1)));
             properties.push((DIRECTIONAL_MODE_DISTANCE, GDValue::Int(config.distance)));
@@ -792,6 +800,7 @@ pub fn move_trigger(
 /// * `target_order`: Target order (of what, I don't know); Default: 0
 /// * `target_channel`: Target channel (once again, I don't know); Default: 0
 /// * `disabled`: Disabled startpos? Default: false
+#[must_use]
 pub fn start_pos(
     config: &GDObjConfig,
     gameplay_settings: StartposConfig,
@@ -867,6 +876,7 @@ pub fn start_pos(
 /// * `config`: General object options, such as position and scale
 /// * `fade_time`: Time to fade into the colour
 /// * `copy_colour`: Optional [`CopyColourConfig`]
+#[must_use]
 pub fn colour_trigger(
     config: &GDObjConfig,
     colour_cfg: ColourTriggerConfig,
@@ -874,9 +884,9 @@ pub fn colour_trigger(
     copy_colour: Option<CopyColourConfig>,
 ) -> GDObject {
     let mut properties = vec![
-        (RED, GDValue::Int(colour_cfg.colour.red as i32)),
-        (GREEN, GDValue::Int(colour_cfg.colour.green as i32)),
-        (BLUE, GDValue::Int(colour_cfg.colour.blue as i32)),
+        (RED, GDValue::Int(i32::from(colour_cfg.colour.red))),
+        (GREEN, GDValue::Int(i32::from(colour_cfg.colour.green))),
+        (BLUE, GDValue::Int(i32::from(colour_cfg.colour.blue))),
         (DURATION_GROUP_TRIGGER_CHANCE, GDValue::Float(fade_time)),
         (
             USING_PLAYER_COLOUR_1,
@@ -918,6 +928,7 @@ pub fn colour_trigger(
 /// * `exclusive_pulse`: disable all other pulses of the same ID when this trigger is activated
 /// * `pulse_target`: Target group/channel of pulse. See [`PulseTarget`]
 /// * `pulse_mode`: Colour settings of this pulse. See [`PulseMode`]
+#[must_use]
 pub fn pulse_trigger(
     config: &GDObjConfig,
     pulse_fade_in_time: f64,
@@ -950,9 +961,9 @@ pub fn pulse_trigger(
     match pulse_mode {
         PulseMode::Colour(c) => {
             properties.extend_from_slice(&[
-                (RED, GDValue::Int(c.red as i32)),
-                (GREEN, GDValue::Int(c.green as i32)),
-                (BLUE, GDValue::Int(c.blue as i32)),
+                (RED, GDValue::Int(i32::from(c.red))),
+                (GREEN, GDValue::Int(i32::from(c.green))),
+                (BLUE, GDValue::Int(i32::from(c.blue))),
             ]);
         }
         PulseMode::HSV(h) => {
@@ -975,7 +986,8 @@ pub fn pulse_trigger(
 /// * `target_group`: Target group to stop/pause/resume
 /// * `stop_mode`: Stop mode (see [`StopMode`] struct)
 /// * `use_control_id`: Only stops certain triggers within a group if enabled.
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn stop_trigger(
     config: &GDObjConfig,
     target_group: i16,
@@ -1000,7 +1012,8 @@ pub fn stop_trigger(
 /// * `target_group`: Target group to stop/pause/resume
 /// * `opacity`: Opacity to set group at
 /// * `fade_time`: Time to fade to the opacity
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn alpha_trigger(
     config: &GDObjConfig,
     target_group: i16,
@@ -1024,7 +1037,8 @@ pub fn alpha_trigger(
 /// * `config`: General object options, such as position and scale
 /// * `target_group`: Target group to stop/pause/resume
 /// * `activate_group`: Active group instead of deactivating?
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn toggle_trigger(config: &GDObjConfig, target_group: i16, activate_group: bool) -> GDObject {
     GDObject::new(
         TRIGGER_TOGGLE,
@@ -1042,6 +1056,7 @@ pub fn toggle_trigger(config: &GDObjConfig, target_group: i16, activate_group: b
 /// * `transition`: Type of transition. See [`TransitionType`] struct
 /// * `mode`: Mode for transition (enter/exit only). See [`TransitionMode`] struct
 /// * `target_channel`: Optional target channel argument which specifies a channel for this transition.
+#[must_use]
 pub fn transition_object(
     config: &GDObjConfig,
     transition: TransitionType,
@@ -1065,7 +1080,8 @@ pub fn transition_object(
 /// Returns a reverse gameplay trigger
 /// # Arguments
 /// * `config`: General object options, such as position and scale
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn reverse_gameplay(config: &GDObjConfig) -> GDObject {
     GDObject::new(TRIGGER_REVERSE_GAMEPLAY, config, vec![])
 }
@@ -1074,7 +1090,8 @@ pub fn reverse_gameplay(config: &GDObjConfig) -> GDObject {
 /// # Arguments
 /// * `config`: General object options, such as position and scale
 /// * `target_group`: group that is linked visibly
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn link_visible(config: &GDObjConfig, target_group: i16) -> GDObject {
     GDObject::new(
         TRIGGER_LINK_VISIBLE,
@@ -1087,7 +1104,8 @@ pub fn link_visible(config: &GDObjConfig, target_group: i16) -> GDObject {
 /// # Arguments
 /// * `config`: General object options, such as position and scale
 /// * `time_scale`: How much to speed up/slow down time by. 1.0 is the default
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn timewarp(config: &GDObjConfig, time_scale: f64) -> GDObject {
     GDObject::new(
         TRIGGER_TIME_WARP,
@@ -1099,7 +1117,8 @@ pub fn timewarp(config: &GDObjConfig, time_scale: f64) -> GDObject {
 /// Returns a trigger that shows the player
 /// # Arguments
 /// * `config`: General object options, such as position and scale
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn show_player(config: &GDObjConfig) -> GDObject {
     GDObject::new(1613, config, vec![])
 }
@@ -1107,7 +1126,8 @@ pub fn show_player(config: &GDObjConfig) -> GDObject {
 /// Returns a trigger that hides the player
 /// # Arguments
 /// * `config`: General object options, such as position and scale
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn hide_player(config: &GDObjConfig) -> GDObject {
     GDObject::new(1612, config, vec![])
 }
@@ -1115,7 +1135,8 @@ pub fn hide_player(config: &GDObjConfig) -> GDObject {
 /// Returns a trigger that shows the player trail
 /// # Arguments
 /// * `config`: General object options, such as position and scale
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn show_player_trail(config: &GDObjConfig) -> GDObject {
     GDObject::new(ENABLE_PLAYER_TRAIL, config, vec![])
 }
@@ -1123,7 +1144,8 @@ pub fn show_player_trail(config: &GDObjConfig) -> GDObject {
 /// Returns a trigger that hides the player trail
 /// # Arguments
 /// * `config`: General object options, such as position and scale\
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn hide_player_trail(config: &GDObjConfig) -> GDObject {
     GDObject::new(DISABLE_PLAYER_TRAIL, config, vec![])
 }
@@ -1131,7 +1153,8 @@ pub fn hide_player_trail(config: &GDObjConfig) -> GDObject {
 /// Returns a trigger that enables the background effect
 /// # Arguments
 /// * `config`: General object options, such as position and scale
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn bg_effect_on(config: &GDObjConfig) -> GDObject {
     GDObject::new(BG_EFFECT_ON, config, vec![])
 }
@@ -1139,7 +1162,8 @@ pub fn bg_effect_on(config: &GDObjConfig) -> GDObject {
 /// Returns a trigger that disables the background effect
 /// # Arguments
 /// * `config`: General object options, such as position and scale
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn bg_effect_off(config: &GDObjConfig) -> GDObject {
     GDObject::new(BG_EFFECT_OFF, config, vec![])
 }
@@ -1148,7 +1172,8 @@ pub fn bg_effect_off(config: &GDObjConfig) -> GDObject {
 /// # Arguments
 /// * `config`: General object options, such as position and scale
 /// * `target_group`: group that is to be reset
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn group_reset(config: &GDObjConfig, target_group: i16) -> GDObject {
     GDObject::new(
         TRIGGER_RESET_GROUP,
@@ -1163,7 +1188,8 @@ pub fn group_reset(config: &GDObjConfig, target_group: i16) -> GDObject {
 /// * `strength`: Strength of shake
 /// * `interval`: Interval in seconds between each shake
 /// * `duration`: Total duration of shaking
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn shake_trigger(
     config: &GDObjConfig,
     strength: i32,
@@ -1186,7 +1212,8 @@ pub fn shake_trigger(
 /// * `config`: General object options, such as position and scale
 /// * `mod_x`: X-axis speed of BG in terms of player speed. Default is 0.3
 /// * `mod_y`: Y-axis speed of BG in terms of player speed. Default is 0.5
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn bg_speed(config: &GDObjConfig, mod_x: f64, mod_y: f64) -> GDObject {
     GDObject::new(
         BG_SPEED_CONFIG,
@@ -1203,7 +1230,8 @@ pub fn bg_speed(config: &GDObjConfig, mod_x: f64, mod_y: f64) -> GDObject {
 /// * `config`: General object options, such as position and scale
 /// * `mod_x`: X-axis speed of MG in terms of player speed. Default is 0.3
 /// * `mod_y`: Y-axis speed of MG in terms of player speed. Default is 0.5
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn mg_speed(config: &GDObjConfig, mod_x: f64, mod_y: f64) -> GDObject {
     GDObject::new(
         MG_SPEED_CONFIG,
@@ -1224,7 +1252,8 @@ pub fn mg_speed(config: &GDObjConfig, mod_x: f64, mod_y: f64) -> GDObject {
 /// * `stop_move`: Stops the player from moving
 /// * `stop_rotation`: Stops the player's rotation
 /// * `stop_slide`: Stops the player from sliding after a force
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn player_control(
     config: &GDObjConfig,
     p1: bool,
@@ -1253,6 +1282,7 @@ pub fn player_control(
 /// * `config`: General object options, such as position and scale
 /// * `gravity`: how much gravity.
 /// * `target_player`: (Optional) Player target for this gravity trigger
+#[must_use]
 pub fn gravity_trigger(
     config: &GDObjConfig,
     gravity: f64,
@@ -1274,6 +1304,7 @@ pub fn gravity_trigger(
 /// * `no_effects`: Disables visual end effects
 /// * `instant`: Teleoprts the player instead of doing the default end pull animation
 /// * `no_sfx`: Disables end sound effects
+#[must_use]
 pub fn end_trigger(
     config: &GDObjConfig,
     spawn_id: Option<i16>,
@@ -1308,7 +1339,8 @@ pub fn end_trigger(
 /// * `timer`: Is a timer?
 /// * `align`: Visual alignment of counter object. See [`ItemAlign`] struct.
 /// * `seconds_only`: Show only seconds if timer?
-/// * `special_mode`: Other special mode of timer. See CounterMode struct.
+/// * `special_mode`: Other special mode of timer. See [`CounterMode`] struct.
+#[must_use]
 pub fn counter_object(
     config: &GDObjConfig,
     item: Item,
@@ -1357,6 +1389,7 @@ pub fn counter_object(
 /// * `id_sign`: sign mode of the result after both operands are evaluated; see [`SignMode`] enum.
 /// * `result_sign`: sign mode of the final result; see [`SignMode`] enum.
 #[allow(clippy::too_many_arguments)]
+#[must_use]
 pub fn item_edit(
     config: &GDObjConfig,
     operand1: Option<Item>,
@@ -1372,10 +1405,8 @@ pub fn item_edit(
     result_sign: SignMode,
 ) -> GDObject {
     // set default values
-    let mod_op = match multiply_mod {
-        true => Op::Mul,
-        false => Op::Div,
-    };
+    let mod_op = if multiply_mod { Op::Mul } else { Op::Div };
+
     let id_op = match id_op {
         Some(op) => op,
         None => Op::Add,
@@ -1427,6 +1458,7 @@ pub fn item_edit(
 /// The round and sign modes are applied at the end of evaluation to each operand.
 /// The right-hand side will be just the modifier if the item id is left as 0 (not specified).
 /// This is useful when it is necessary to compare an item value and an integer or float literal.
+#[must_use]
 pub fn item_compare(
     config: &GDObjConfig,
     true_id: i16,
@@ -1478,6 +1510,7 @@ pub fn item_compare(
 /// * `persistent`: make this item persistent?
 /// * `target_all`: Target all persistent items?
 /// * `reset`: Reset item(s) to 0?
+#[must_use]
 pub fn persistent_item(
     config: &GDObjConfig,
     item_id: i16,
@@ -1507,6 +1540,7 @@ pub fn persistent_item(
 /// * `chance`: chance to trigger group 1
 /// * `target_group1`: target group 1
 /// * `target_group1`: target group 2
+#[must_use]
 pub fn random_trigger(
     config: &GDObjConfig,
     chance: f64,
@@ -1533,6 +1567,8 @@ pub fn random_trigger(
 /// * `reset_remap`: Resets the remapping of group IDs
 /// * `spawn_ordered`: Spawns constituents of group in the order of x-position
 /// * `preview_disable`: prevents the trigger's resulting spawns from being rendered in editor preview
+#[must_use]
+#[allow(clippy::too_many_arguments)]
 pub fn spawn_trigger(
     config: &GDObjConfig,
     spawn_id: i16,
@@ -1563,7 +1599,8 @@ pub fn spawn_trigger(
 /// * `config`: General object options, such as position and scale
 /// * `target_group`: Spawns this group
 /// * `activate_group`: Activate this group (instead of toggling off)?
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn on_death(config: &GDObjConfig, target_group: i16, activate_group: bool) -> GDObject {
     GDObject::new(
         TRIGGER_ON_DEATH,
@@ -1581,6 +1618,7 @@ pub fn on_death(config: &GDObjConfig, target_group: i16, activate_group: bool) -
 /// * `particle_group`: Group that contains the particle objects
 /// * `position_group`: Group at which the particles will be spawned
 /// * `spawn_cfg`: Spawning configure for the particles themselves. See [`ParticleSpawnConfig`]
+#[must_use]
 pub fn spawn_particle(
     config: &GDObjConfig,
     particle_group: i16,
@@ -1626,7 +1664,8 @@ pub fn spawn_particle(
 /// * `config`: General object options, such as position and scale
 /// * `id`: Collision block ID
 /// * `dynamic`: Does this block register collisions with other collision blocks?
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn collision_block(config: &GDObjConfig, id: i16, dynamic: bool) -> GDObject {
     GDObject::new(
         COLLISION_BLOCK,
@@ -1646,7 +1685,8 @@ pub fn collision_block(config: &GDObjConfig, id: i16, dynamic: bool) -> GDObject
 /// * `claim_touch`: Disable buffer clicking?
 /// * `multi_activate`: Allow multiple activations?
 /// * `spawn_only`: Spawn only without toggling?
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn toggle_block(
     config: &GDObjConfig,
     target_group: i16,
@@ -1673,7 +1713,8 @@ pub fn toggle_block(
 /// * `config`: General object options, such as position and scale
 /// * `state_on`: Group that is activated when the player enters this block's hitbox
 /// * `state_off`: Group that is activated when the player exits this block's hitbox
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn state_block(config: &GDObjConfig, state_on: i16, state_off: i16) -> GDObject {
     GDObject::new(
         COLLISION_STATE_BLOCK,
@@ -1695,7 +1736,8 @@ pub fn state_block(config: &GDObjConfig, state_on: i16, state_off: i16) -> GDObj
 ///   instead of when they start colliding.
 ///
 /// **Note**: At least one of the collider blocks must be dynamic for this collision to register.
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn collision_trigger(
     config: &GDObjConfig,
     collider_cfg: ColliderConfig,
@@ -1737,7 +1779,8 @@ pub fn collision_trigger(
 /// * `collider_cfg`: Settings for colliders for this collision detection. See [`ColliderConfig`]
 /// * `true_id`: ID of group that is activated if the two colliders collide
 /// * `false_id`: ID of group that is activated if the two colliders do not collide
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn instant_coll_trigger(
     config: &GDObjConfig,
     collider_cfg: ColliderConfig,
@@ -1775,6 +1818,7 @@ pub fn instant_coll_trigger(
 /// * `config`: General object options, such as position and scale
 /// * `time_cfg`: Main trigger configuration. See [`TimeTriggerConfig`].
 /// * `target_group`: Group that is activated when the timer reaches the target value
+#[must_use]
 pub fn time_trigger(
     config: &GDObjConfig,
     time_cfg: TimeTriggerConfig,
@@ -1805,7 +1849,8 @@ pub fn time_trigger(
 /// * `config`: General object options, such as position and scale
 /// * `id`: Timer ID
 /// * `stop`: If enabled, stops the timer; otherwise, starts the timer.
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn time_control(config: &GDObjConfig, id: i16, stop: bool) -> GDObject {
     GDObject::new(
         TRIGGER_TIME_CONTROL,
@@ -1824,7 +1869,8 @@ pub fn time_control(config: &GDObjConfig, id: i16, stop: bool) -> GDObject {
 /// * `target_group`: If enabled, stops the timer; otherwise, starts the timer.
 /// * `target_time`: At what time the timer should be to activate objects in `target_group`.
 /// * `multi_activate`: Should this event be triggerable multiple times?
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn time_event(
     config: &GDObjConfig,
     id: i16,
@@ -1852,6 +1898,7 @@ pub fn time_event(
 /// * `zoom`: Resulting camera zoom. Default is 1.0
 /// * `time`: Time to zoom
 /// * `easing`: Zoom easing config. See [`MoveEasing`] struct.
+#[must_use]
 pub fn camera_zoom(
     config: &GDObjConfig,
     zoom: f64,
@@ -1877,7 +1924,8 @@ pub fn camera_zoom(
 /// * `offset_x`: Center offset from this object in x axis
 /// * `offset_y`: Center offset from this object in y axis
 /// * `opacity`: Opacity of guidelines
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn camera_guide(
     config: &GDObjConfig,
     zoom: f64,
@@ -1907,7 +1955,8 @@ pub fn camera_guide(
 /// * `follow_time`: Time that the follow group is followed for. -1.0 = infinite.
 /// * `target_group`: Group that is following
 /// * `follow_group`: Group that is being followed
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn follow_trigger(
     config: &GDObjConfig,
     x_mod: f64,
@@ -1934,7 +1983,8 @@ pub fn follow_trigger(
 /// * `config`: General object options, such as position and scale
 /// * `target_group`: Objects to animate
 /// * `animation`: Animation ID, provided in [`Anim`] enum
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn animate_trigger(config: &GDObjConfig, target_group: i16, animation: Anim) -> GDObject {
     GDObject::new(
         TRIGGER_ANIMATE,
@@ -1954,7 +2004,8 @@ pub fn animate_trigger(config: &GDObjConfig, target_group: i16, animation: Anim)
 /// * `target_count`: Target count of item at `item_id`
 /// * `activate_group`: Whether or not to activate the target group
 /// * `multi_activate`: Whether or not this trigger is multi-activatable
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn count_trigger(
     config: &GDObjConfig,
     item_id: i16,
@@ -1984,7 +2035,8 @@ pub fn count_trigger(
 /// Chances are considered relative to each other, meaning that they are not
 /// precentage-based. Two groups with the same relative chance will have the same
 /// (50-50) chance to be triggered
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn advanced_random_trigger(config: &GDObjConfig, probabilities: Vec<(i16, i32)>) -> GDObject {
     GDObject::new(
         TRIGGER_ADVANCED_RANDOM,
@@ -2005,7 +2057,8 @@ pub fn advanced_random_trigger(config: &GDObjConfig, probabilities: Vec<(i16, i3
 /// * `y_reference`: Reference position for the element on the Y-axis
 /// * `x_ref_relative`: Whether or not the x-axis position scales with aspect ratio
 /// * `y_ref_relative`: Whether or not the y-axis position scales with aspect ratio
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn ui_config_trigger(
     config: &GDObjConfig,
     target_group: i16,
@@ -2040,6 +2093,7 @@ pub fn ui_config_trigger(
 /// * `bounding_box`: Optional vertices of a bounding box that limit the position of the rotation group.
 ///
 /// The tuple corresponds to the `MinX`, `MinY`, `MaxX`, `MaxY` group ids respectively in the rotate trigger.
+#[must_use]
 pub fn rotate_trigger(
     config: &GDObjConfig,
     move_time: f64,
@@ -2118,6 +2172,7 @@ pub fn rotate_trigger(
 /// * `center_group_id`: Center of group that is being scaled. Leave as 0 to use the default center
 /// * `target_group`: Group that is being scaled.
 /// * `duration`: How long the scaling will be
+#[must_use]
 pub fn scale_trigger(
     config: &GDObjConfig,
     scale_config: ScaleConfig,
@@ -2155,7 +2210,8 @@ pub fn scale_trigger(
 /// * `max_speed`: Speed limit of the following group
 /// * `move_time`: How long the group will follow the player
 /// * `target_group`: The group that is following the player's y-pos
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn follow_player_y(
     config: &GDObjConfig,
     speed: f64,
@@ -2182,7 +2238,8 @@ pub fn follow_player_y(
 /// Returns a middleground config trigger
 /// # Arguments
 /// * `config`: General object options, such as position and scale
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn mg_config(
     config: &GDObjConfig,
     offset_y: i32,
@@ -2195,17 +2252,20 @@ pub fn mg_config(
 
 // util fn to add easing to properties if it is specified
 fn add_easing(properties: &mut Vec<(u16, GDValue)>, easing: Option<(MoveEasing, f64)>) {
-    if let Some((easing, rate)) = easing {
-        properties.extend_from_slice(&[
-            (MOVE_EASING, GDValue::Easing(easing)),
-            (EASING_RATE, GDValue::Float(rate)),
-        ])
-    }
+    let Some((easing, rate)) = easing else {
+        return;
+    };
+
+    properties.extend_from_slice(&[
+        (MOVE_EASING, GDValue::Easing(easing)),
+        (EASING_RATE, GDValue::Float(rate)),
+    ]);
 }
 
 /// Returns an event config trigger
 /// # Arguments
 /// * `config`: General object options, such as position and scale
+#[must_use]
 pub fn event_trigger(
     config: &GDObjConfig,
     target_group: i16,
@@ -2230,6 +2290,7 @@ pub fn event_trigger(
 /// # Arguments
 /// * `config`: General object options, such as position and scale
 /// * `middleground`: Middleground to change to
+#[must_use]
 pub fn middle_ground_trigger(config: &GDObjConfig, middleground: MiddleGround) -> GDObject {
     GDObject::new(
         TRIGGER_MIDDLEGROUND_CHANGE,
@@ -2246,6 +2307,7 @@ pub fn middle_ground_trigger(config: &GDObjConfig, middleground: MiddleGround) -
 /// * `dual_mode`: Blocks 2nd player's clicks. Deprecated in favour of [`OptionalPlayerTarget::Player1`]
 /// * `toggle`: Toggles a specific activation mode. See [`TouchToggle`]
 /// * `target_player`: Only registers clicks from one player. See [`OptionalPlayerTarget`]
+#[must_use]
 pub fn touch_trigger(
     config: &GDObjConfig,
     target_group: i16,
@@ -2271,6 +2333,7 @@ pub fn touch_trigger(
 /// # Arguments
 /// * `config`: General object options, such as position and scale
 /// * `effect_id`: Area effect that is stopped
+#[must_use]
 pub fn area_stop(config: &GDObjConfig, effect_id: i16) -> GDObject {
     GDObject::new(
         TRIGGER_AREA_STOP,

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -2,35 +2,39 @@
 
 use crate::gdobj::{GDValue, Group};
 
-const LCG_MULTIPLIER: u64 = 214013;
-const LCG_CONSTANT: u64 = 2531011;
+const LCG_MULTIPLIER: u64 = 214_013;
+const LCG_CONSTANT: u64 = 2_531_011;
 
 /// Determines the next seed from a starting seed as generated in Geometry Dash.
-#[inline(always)]
-pub fn next_seed(seed: u64) -> u64 {
+#[inline]
+#[must_use]
+pub const fn next_seed(seed: u64) -> u64 {
     seed.wrapping_mul(LCG_MULTIPLIER).wrapping_add(LCG_CONSTANT)
 }
 
 /// Mutating version of [`next_seed`]
-#[inline(always)]
-pub fn next_seed_mut(seed: &mut u64) {
+#[inline]
+pub const fn next_seed_mut(seed: &mut u64) {
     *seed = seed.wrapping_mul(LCG_MULTIPLIER).wrapping_add(LCG_CONSTANT);
 }
 
 /// Function used by GD to generate a new seed. Internally known as `fast_rand_0_1`.
 /// Unlike the actual PRNG used in GD, this function *DOES NOT* automatically update the seed.
-#[inline(always)]
-pub fn fast_rand_bits(seed: u64) -> u64 {
+#[inline]
+#[must_use]
+pub const fn fast_rand_bits(seed: u64) -> u64 {
     (next_seed(seed) >> 16) & 0x7fff
 }
 
 /// Utility function which normalises result from [`fast_rand_bits`] to the range \[0.0, 1.0].
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn fast_rand_bits_norm(seed: u64) -> f64 {
     fast_rand_bits(seed) as f64 / 32767.0
 }
 
 /// Checks if the seed will activate group 1 or 2 in a random trigger.
+///
 /// The chance must be given as a float in the range \[0.0, 1.0].
 /// The function returns true if the group 1 will be activated, and false if group 2 will be activated.
 ///
@@ -40,7 +44,8 @@ pub fn fast_rand_bits_norm(seed: u64) -> f64 {
 ///
 /// **WARNING**: This function may rarely, for an unknown reason, erroneously determine that
 /// a seed will activate a group when in reality, it won't. Please be mindful of this when checking seeds.
-#[inline(always)]
+#[inline]
+#[must_use]
 pub fn check_seed_random(seed: u64, chance: f64) -> bool {
     // Compare against the chance threshold
     fast_rand_bits_norm(seed) < chance
@@ -58,6 +63,7 @@ pub fn check_seed_random(seed: u64, chance: f64) -> bool {
 ///
 /// **WARNING**: This function may rarely, for an unknown reason, erroneously determine that
 /// a seed will activate a group when in reality, it won't. Please be mindful of this when checking seeds.
+#[must_use]
 pub fn check_seed_advanced_random(seed: u64, probabilities: &GDValue) -> Option<Group> {
     let prob_list;
     if let GDValue::ProbabilitiesList(probs) = probabilities {
@@ -80,17 +86,19 @@ pub fn check_seed_advanced_random(seed: u64, probabilities: &GDValue) -> Option<
     // Get total chance and threshold
     let total_chance: i32 = prob_list.iter().map(|(_, chance)| chance).sum();
     // threshold is in the range \[0, total_chance]
-    let threshold = fast_rand_bits_norm(seed) * total_chance as f64;
+    let threshold = fast_rand_bits_norm(seed) * f64::from(total_chance);
 
     let mut cumulative_chance = 0;
     let mut chosen_group = prob_list.last().unwrap().0;
 
     // Iterate through all groups until the threshold is reached.
     // If the threshold is never reached, the last group is activated.
-    for (group, chance) in prob_list.iter() {
+    for (group, chance) in prob_list {
         cumulative_chance += chance;
-        if cumulative_chance as f64 >= threshold {
+
+        if f64::from(cumulative_chance) >= threshold {
             chosen_group = *group;
+
             break;
         }
     }

--- a/src/serialiser.rs
+++ b/src/serialiser.rs
@@ -6,15 +6,16 @@ use plist::{Dictionary, Value};
 
 use crate::core::b64_encode;
 
-fn zlib_compress(s: String) -> Vec<u8> {
+fn zlib_compress(s: &str) -> Vec<u8> {
     let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
     encoder.write_all(s.as_bytes()).unwrap();
     encoder.finish().unwrap()
 }
 
 /// Returns the encrypted level string as `Vec<u8>` from a `GDLevel` object string
-pub fn encrypt_level_str(s: String) -> Vec<u8> {
-    let compress = zlib_compress(s.clone());
+#[must_use]
+pub fn encrypt_level_str(s: &str) -> Vec<u8> {
+    let compress = zlib_compress(s);
     let mut data = b"H4sIAAAAAA".to_vec();
     data.extend_from_slice(&compress[2..compress.len() - 4]);
     let crc_checksum = crc32fast::hash(s.as_bytes()).to_le_bytes();
@@ -22,7 +23,7 @@ pub fn encrypt_level_str(s: String) -> Vec<u8> {
 
     data.extend_from_slice(&crc_checksum);
     data.extend_from_slice(&size);
-    let base64 = b64_encode(data).replace("+", "-").replace("/", "_");
+    let base64 = b64_encode(data).replace('+', "-").replace('/', "_");
 
     let mut header = b"H4sIAAAAAAAAC".to_vec();
     header.extend_from_slice(&base64.as_bytes()[13..]);
@@ -30,29 +31,29 @@ pub fn encrypt_level_str(s: String) -> Vec<u8> {
 }
 
 /// Returns the encrypted savefile string from a stringified `Levels` struct
-pub fn encrypt_savefile_str(s: String) -> Vec<u8> {
-    encrypt_level_str(s).iter().map(|c| *c ^ 11).collect()
+#[must_use]
+pub fn encrypt_savefile_str(s: &str) -> Vec<u8> {
+    encrypt_level_str(s).iter().map(|c| *c ^ 0xb).collect()
 }
 
 /// Parses an XML dictionary to a string that matches GD savefile format.
 ///
 /// # Arguments
-/// * `dict`: plist::Dictionary to parse.
+/// * `dict`: [`plist::Dictionary`] to parse.
 /// * `root`: Is the input the root dict?
 ///
 /// Returns the stringified dictionary
+#[must_use]
 pub fn stringify_xml(dict: &Dictionary, root: bool) -> String {
     if dict.is_empty() {
         return "<d />".to_owned();
-    };
+    }
 
     let mut dict_str = String::with_capacity(4_096);
-    dict_str.push_str(match root {
-        true => "<dict>",
-        false => "<d>",
-    });
 
-    for (key, value) in dict.iter() {
+    dict_str.push_str(if root { "<dict>" } else { "<d>" });
+
+    for (key, value) in dict {
         let _ = write!(dict_str, "<k>{key}</k>");
         match value {
             Value::String(s) => {
@@ -78,9 +79,7 @@ pub fn stringify_xml(dict: &Dictionary, root: bool) -> String {
         }
     }
 
-    dict_str.push_str(match root {
-        true => "</dict>",
-        false => "</d>",
-    });
+    dict_str.push_str(if root { "</dict>" } else { "</d>" });
+
     dict_str
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -15,11 +15,13 @@ use crate::{
 fn benchmark<F: Fn() -> R, R>(name: &str, f: F) -> R {
     let start = Instant::now();
     let result = f();
+
     println!(
         "{name}: {:.3}ms",
         start.elapsed().as_micros() as f64 / 1000.0
     );
-    return result;
+
+    result
 }
 
 #[test]
@@ -126,8 +128,8 @@ fn ref_vs_copy_benchmark() {
         }
     }
     let objs = level.get_decrypted_data().unwrap().objects.len();
-    let avg_copy_time = copy_time as f64 / (1_000 * count) as f64;
-    let avg_ref_time = ref_time as f64 / (1_000 * count) as f64;
+    let avg_copy_time = copy_time as f64 / f64::from(1_000 * count);
+    let avg_ref_time = ref_time as f64 / f64::from(1_000 * count);
 
     println!(
         "Objects: {objs}; {count} tests\nAverage copy time: {:.3}us\nAverage ref time: {:.3}us\nAverage copy time per object: {:.3}us\nAverage ref time per object: {:.3}us",
@@ -181,15 +183,4 @@ fn advanced_random_predict() {
         check_seed_advanced_random(seed, &probabilities).unwrap(),
         Group::Regular(1)
     );
-}
-
-#[test]
-#[ignore]
-fn _temp_read_objs() {
-    let level = Level::from_gmd("GMDS/spawn remap.gmd").unwrap();
-    let data = level.get_decrypted_data().unwrap();
-
-    for (idx, obj) in data.objects.iter().enumerate() {
-        println!("{idx}: {obj:?}");
-    }
 }


### PR DESCRIPTION
This includes:
- Add #[must_use] to functions
- Use &str instead of String to avoid cloing and improve performance
- Remove .iter and .into_iter in place of & and &mut respectively
- Remove #[inline(always)] in place of #[inline]
- Derive more attributes like Default, Copy, PartialOrd, Ord, Eq, and Hash
- Use guard clauses with let else statements to reduce indentation levels