### PR TITLE
Performance + Doc Fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,7 @@ repository = "https://github.com/ArrowSlashArrow/gdlib"
 keywords = ["fast", "api", "gd"]
 categories = ["encoding", "api-bindings", "games"]
 readme = "README.md"
-authors = ["ArrowSlashArrow arrowslasharrow.dev@gmail.com"]
-
+authors = ["ArrowSlashArrow <arrowslasharrow.dev@gmail.com>"]
 
 [dependencies]
 aho-corasick = "1.1.3"
@@ -24,7 +23,12 @@ flate2 = { version = "1.1.2", features = ["zlib"] }
 itoa = "1.0.15"
 phf = { version = "0.13.1", features = ["macros"] }
 plist = "1.7.4"
+rayon = { version = "1.12.0", optional = true }
 smallvec = "1.15.1"
+
+[features]
+default = []
+parallel = ["dep:rayon"]
 
 [build-dependencies]
 syn = { version = "2", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Features
 * Easy modification of objects through built-in methods and objects
 * Full support for read from and writing to .dat and .gmd files
 * Optimized to be fast and lightweight
+* Optional `parallel` feature to use Rayon-backed parallel object parse/serialise and savefile xor passes (use `cargo add gdlib --features parallel`)
 
 ## Usage instructions
 This crate can be added to a project by running `cargo add gdlib`.

--- a/build.rs
+++ b/build.rs
@@ -6,7 +6,7 @@ use syn::{Expr, ExprArray, ExprLit, ExprTuple, Item, Lit};
 // all of the currently implemented ids for objects and properties as consts.
 // currently broken due to `kAXX` properties
 
-fn to_const_name(s: String) -> String {
+fn to_const_name(s: &str) -> String {
     let mut seen_underscore = false;
     s.chars()
         .map(|c| {
@@ -37,7 +37,7 @@ fn handle_tuple(buffer: &mut String, tuple: ExprTuple) {
             }
         }
     }
-    let const_name = to_const_name(name);
+    let const_name = to_const_name(&name);
     writeln!(buffer, "    pub const {const_name}: i32 = {id};").unwrap();
 }
 
@@ -48,6 +48,7 @@ fn handle_tuple(buffer: &mut String, tuple: ExprTuple) {
 fn main() {
     let mut properties_out_str = String::new();
     let mut objects_out_str = String::new();
+    let mut group_property_ids = Vec::new();
     let other_file = fs::read_to_string("src/gdobj/lookup.rs").unwrap();
     let file = fs::read_to_string("src/gdobj/mod.rs").unwrap();
 
@@ -80,19 +81,27 @@ fn main() {
             let id = split.next().unwrap();
             let mut tuple_split = split.next().unwrap().split(", ");
             let desc = tuple_split.next().unwrap();
-            let const_name = to_const_name(desc.to_string());
+            let const_name = to_const_name(desc);
+            let prop_type = tuple_split.next().unwrap_or_default();
 
             writeln!(
                 properties_out_str,
                 "    pub const {const_name}: u16 = {id};"
             )
             .unwrap();
+
+        if prop_type.contains("GDObjPropType::Group") {
+                group_property_ids.push(id.to_string());
+            }
         } else if line.starts_with(
             "pub static PROPERTY_TABLE: Map<u16, (&'static str, GDObjPropType)> = phf_map!",
         ) {
             seen_map = true;
         }
     }
+
+    let gids_len = group_property_ids.len();
+    let group_ids_literal = group_property_ids.join(", ");
 
     let out_str = format!(
         "\
@@ -102,7 +111,13 @@ pub mod objects {{
 
 /// Property ids submodule
 pub mod properties {{
-{properties_out_str}}}"
+{properties_out_str}}}
+
+/// Property metadata submodule
+pub mod metadata {{
+    pub static GROUP_PROPERTY_IDS: &[u16; {gids_len}] = &[{group_ids_literal}];
+}}
+"
     );
 
     let out_dir = env::var_os("OUT_DIR").unwrap();

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,4 +1,4 @@
-use gdlib::{core::GDError, gdlevel::Level, gdobj::Group};
+use gdlib::{GDError, gdlevel::Level, gdobj::Group};
 
 fn main() -> Result<(), GDError> {
     // Load level from .gmd file

--- a/src/core.rs
+++ b/src/core.rs
@@ -8,15 +8,54 @@ use std::{
     path::{Path, PathBuf},
 };
 
-/// Error enum
+macro_rules! count_exprs {
+    () => { 0 };
+    ($e:expr) => { 1 };
+    ($e:expr, $($es:expr),+) => { 1 + count_exprs!($($es),*) };
+}
+macro_rules! build_plist_tags {
+    ($($find:expr => $replace:expr),* $(,)?) => {
+        const PLIST_TAGS_FIND: [&str; count_exprs!($($find),*)] = [$($find),*];
+        const PLIST_TAGS_REPLACE: [&str; count_exprs!($($replace),*)] = [$($replace),*];
+    };
+}
+
+build_plist_tags! {
+    "<k>" => "<key>",
+    "</k>" => "</key>",
+    "<i>" => "<integer>",
+    "</i>" => "</integer>",
+    "<d>" => "<dict>",
+    "</d>" => "</dict>",
+    "<d />" => "<dict />",
+    "<t/>" => "<true/>",
+    "<f/>" => "<false/>",
+    "<t />" => "<true />",
+    "<f />" => "<false />",
+    "<s>" => "<string>",
+    "</s>" => "</string>",
+    "<r>" => "<real>",
+    "</r>" => "</real>",
+}
+
+/// `GDLib`'s primary error type.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum GDError {
-    /// Standard IO failure
+    /// Standard `std::io::Error`
     Io(std::io::Error),
     /// Data could not be parsed from its raw form
     DecodeError(DecodeError),
     /// Unsuccessful plist parse
     BadPlist(plist::Error),
+    /// `AhoCorasick` error (UTF-8 parsing issues)
+    AhoCorasick(aho_corasick::BuildError),
+    /// `FromUtf8Error` when converting decrypted bytes to string
+    FromUtf8Error(std::string::FromUtf8Error),
+    /// The savefile was invalid and could not be parsed
+    BadParse,
+    /// No available save file was found to use.
+    NoAvailableSavefile,
 }
 
 impl Error for GDError {
@@ -25,6 +64,9 @@ impl Error for GDError {
             Self::Io(e) => Some(e),
             Self::DecodeError(e) => e.source(),
             Self::BadPlist(e) => e.source(),
+            Self::AhoCorasick(e) => Some(e),
+            Self::FromUtf8Error(e) => Some(e),
+            Self::BadParse | Self::NoAvailableSavefile => None,
         }
     }
 }
@@ -44,19 +86,44 @@ impl From<plist::Error> for GDError {
         Self::BadPlist(value)
     }
 }
+impl From<aho_corasick::BuildError> for GDError {
+    fn from(value: aho_corasick::BuildError) -> Self {
+        Self::AhoCorasick(value)
+    }
+}
+impl From<std::string::FromUtf8Error> for GDError {
+    fn from(value: std::string::FromUtf8Error) -> Self {
+        Self::FromUtf8Error(value)
+    }
+}
+// TODO: make this more verbose, probably better?
+impl From<GDError> for std::fmt::Error {
+    fn from(_: GDError) -> Self {
+        std::fmt::Error
+    }
+}
 
 impl Display for GDError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::DecodeError(d) => write!(f, "File decode failed: {d}"),
             Self::BadPlist(p) => write!(f, "Bad plist: {p}"),
-            Self::Io(io) => write!(f, "{io}"),
+            Self::Io(io) => write!(f, "IO failed: {io}"),
+            Self::AhoCorasick(a) => write!(f, "AhoCorasick UTF-8 build error: {a}"),
+            Self::FromUtf8Error(e) => write!(f, "UTF-8 conversion error: {e}"),
+            Self::BadParse => write!(f, "Savefile was invalid and could not be parsed!"),
+            Self::NoAvailableSavefile => write!(f, "No available save file found!"),
         }
     }
 }
 
 /// Returns path of CCLocalLevels.dat if it exists
+#[must_use]
+// -- TODO --: The fn only supports Windows, need to implement other OSes
 pub fn get_local_levels_path() -> Option<PathBuf> {
+    // TODO: need better way to validate/ensure Windows platforms
+    // TODO: need better way to check all Windows locations for gd?
+    // TODO: make into const
     if let Ok(local_appdata) = env::var("LOCALAPPDATA")
         && Path::new(&local_appdata).exists()
     {
@@ -67,44 +134,22 @@ pub fn get_local_levels_path() -> Option<PathBuf> {
 }
 
 /// Replaces Robtop's plist format with actual plist tags; i.e. `<s>` becomes `<string>`
-pub fn proper_plist_tags(s: String) -> String {
-    // replace gd plist with proper plist
-    // using aho-corasick for single-pass instead of many .replace()s
-    let find = &[
-        "<k>", "</k>", "<i>", "</i>", "<d>", "</d>", "<d />", "<t/>", "<f/>", "<t />", "<f />",
-        "<s>", "</s>", "<r>", "</r>",
-    ];
-    let replace = &[
-        "<key>",
-        "</key>",
-        "<integer>",
-        "</integer>",
-        "<dict>",
-        "</dict>",
-        "<dict />",
-        "<true/>",
-        "<false/>",
-        "<true />",
-        "<false />",
-        "<string>",
-        "</string>",
-        "<real>",
-        "</real>",
-    ];
-    let ac = AhoCorasick::new(find).unwrap();
-    ac.replace_all(&s, replace)
+pub fn proper_plist_tags(s: String) -> Result<String, GDError> {
+    // replace gd plist with proper plist; use aho-corasick for single-pass instead of many .replace()s
+    let ac = AhoCorasick::new(PLIST_TAGS_FIND)?;
+    Ok(ac.replace_all(&s, &PLIST_TAGS_REPLACE))
 }
 
 /// Quick function for decoding base64 bytes
-#[inline(always)]
-pub fn b64_decode<T: AsRef<[u8]> + Debug>(encoded: T) -> Vec<u8> {
-    base64::engine::general_purpose::URL_SAFE
-        .decode(encoded)
-        .unwrap()
+#[inline]
+pub fn b64_decode<T: AsRef<[u8]>>(encoded: T) -> Result<Vec<u8>, GDError> {
+    Ok(base64::engine::general_purpose::URL_SAFE
+        .decode(encoded)?)
 }
 
 /// Quick function for encoding base64 bytes
-#[inline(always)]
-pub fn b64_encode(encoded: Vec<u8>) -> String {
+#[inline]
+#[must_use]
+pub fn b64_encode<T: AsRef<[u8]>>(encoded: T) -> String {
     base64::engine::general_purpose::URL_SAFE.encode(encoded)
 }

--- a/src/deserialiser.rs
+++ b/src/deserialiser.rs
@@ -3,6 +3,8 @@ use std::{fs, io::Read};
 
 use base64::{Engine, engine::general_purpose};
 use flate2::read::DeflateDecoder;
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 
 use crate::{core::GDError, core::get_local_levels_path};
 
@@ -11,18 +13,19 @@ use crate::{core::GDError, core::get_local_levels_path};
 /// # Arguments
 /// * `data`: compressed input data
 ///
-/// Returns decompressed base64ed gzip as a `Vec<u8>` if it sucessfully decoded, otherwise return Error
+/// Returns decompressed base64ed gzip as a `Vec<u8>` if it sucessfully decoded, otherwise returns `GDError`
 pub fn decompress(mut data: Vec<u8>) -> Result<Vec<u8>, GDError> {
     data.retain(|c| *c != 0);
 
     // decode DEFLATE payload
     let decoded = general_purpose::URL_SAFE.decode(data)?;
+    // remove gzip header
     let sliced = &decoded[10..];
 
     let mut decoder = DeflateDecoder::new(sliced);
-    let mut decompressed_buf = Vec::new();
+    let mut decompressed_buf = Vec::with_capacity(decoder.total_out() as usize);
 
-    decoder.read_to_end(&mut decompressed_buf).unwrap();
+    decoder.read_to_end(&mut decompressed_buf)?;
 
     Ok(decompressed_buf)
 }
@@ -34,21 +37,25 @@ pub fn decompress(mut data: Vec<u8>) -> Result<Vec<u8>, GDError> {
 /// * `data`: encrypted payload
 ///
 /// Returns the raw file contents as a `Vec<u8>`
-#[inline(always)]
-pub fn decrypt(mut data: Vec<u8>) -> Vec<u8> {
+#[inline]
+#[must_use]
+pub fn decrypt(mut data: Vec<u8>) -> Result<Vec<u8>, GDError> {
+    #[cfg(feature = "parallel")]
+    data.par_iter_mut().for_each(|c| *c ^= 0x000b);
+
+    #[cfg(not(feature = "parallel"))]
     for c in &mut data {
-        *c ^= 11;
+        *c ^= 0x000b;
     }
-    decompress(data).unwrap()
+    decompress(data)
 }
 
 /// Returns CCLocalLevels.dat decrypted if it exists
 pub fn decode_levels_to_string() -> Result<String, GDError> {
-    let savefile = match fs::read(get_local_levels_path().unwrap()) {
-        Ok(v) => v,
-        Err(e) => return Err(GDError::Io(e)),
-    };
-    let data = decrypt(savefile);
+    let path = get_local_levels_path()
+        .ok_or(GDError::NoAvailableSavefile)?;
+    let savefile = fs::read(&path)?;
+    let data = decrypt(savefile)?;
 
-    Ok(String::from_utf8(data.to_vec()).unwrap())
+    Ok(String::from_utf8(data)?)
 }

--- a/src/gdlevel.rs
+++ b/src/gdlevel.rs
@@ -1,11 +1,14 @@
 //! This file contains the necessary structs for interfacing with the level(s) themselves
 use std::{
-    collections::{BTreeSet, HashMap, HashSet},
+    collections::HashMap,
     fmt::Display,
     fs::{self, read, write},
     io::Cursor,
     path::PathBuf,
 };
+
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 
 use crate::{core::GDError, gdobj::Group};
 
@@ -14,19 +17,19 @@ use plist::{Dictionary, Value};
 use crate::{
     core::{b64_decode, b64_encode, get_local_levels_path, proper_plist_tags},
     deserialiser::{decode_levels_to_string, decompress},
-    gdobj::{GDObjPropType, GDObject, lookup::PROPERTY_TABLE},
+    gdobj::{GDObject, ids::metadata::GROUP_PROPERTY_IDS},
     serialiser::{encrypt_level_str, encrypt_savefile_str, stringify_xml},
 };
 
-/// This is the default level header
+/// The default level header found in GD savefiles.
 pub const DEFAULT_LEVEL_HEADERS: &str = "kS38,1_40_2_125_3_255_11_255_12_255_13_255_4_-1_6_1000_7_1_15_1_18_0_8_1|1_0_2_102_3_255_11_255_12_255_13_255_4_-1_6_1001_7_1_15_1_18_0_8_1|1_0_2_102_3_255_11_255_12_255_13_255_4_-1_6_1009_7_1_15_1_18_0_8_1|1_255_2_255_3_255_11_255_12_255_13_255_4_-1_6_1002_5_1_7_1_15_1_18_0_8_1|1_40_2_125_3_255_11_255_12_255_13_255_4_-1_6_1013_7_1_15_1_18_0_8_1|1_40_2_125_3_255_11_255_12_255_13_255_4_-1_6_1014_7_1_15_1_18_0_8_1|1_0_2_125_3_255_11_255_12_255_13_255_4_-1_6_1005_5_1_7_1_15_1_18_0_8_1|1_0_2_200_3_255_11_255_12_255_13_255_4_-1_6_1006_5_1_7_1_15_1_18_0_8_1|,kA13,0,kA15,0,kA16,0,kA14,,kA6,0,kA7,0,kA25,0,kA17,0,kA18,0,kS39,0,kA2,0,kA3,0,kA8,0,kA4,0,kA9,0,kA10,0,kA22,0,kA23,0,kA24,0,kA27,1,kA40,1,kA41,1,kA42,1,kA28,0,kA29,0,kA31,1,kA32,1,kA36,0,kA43,0,kA44,0,kA45,1,kA46,0,kA33,1,kA34,1,kA35,0,kA37,1,kA38,1,kA39,1,kA19,0,kA26,0,kA20,0,kA21,0,kA11,0;";
 
 /// This struct contains other values found in the levels savefile that aren't of any particular use
 #[derive(Debug, Clone, PartialEq)]
 #[allow(missing_docs)]
 pub struct LevelsFileHeaders {
-    pub llm02: Value,
-    pub llm03: Value,
+    pub llm_02: Value,
+    pub llm_03: Value,
 }
 
 /// This struct contains all the levels of the savefile
@@ -71,42 +74,54 @@ pub enum LevelState {
 
 impl Levels {
     /// Returns the levels in CCLocalLevels.dat if retrievable
-    #[inline(always)]
+    #[inline]
     pub fn from_local() -> Result<Self, GDError> {
         Levels::from_decrypted(decode_levels_to_string()?)
     }
 
     /// Parses raw savefile string into this struct
     pub fn from_decrypted(s: String) -> Result<Self, GDError> {
-        let xmltree = match Value::from_reader_xml(Cursor::new(proper_plist_tags(s).as_bytes())) {
-            Ok(v) => v.into_dictionary().unwrap(),
-            Err(e) => return Err(GDError::BadPlist(e)),
-        };
+        let mut xmltree = Value::from_reader_xml(Cursor::new(s.as_bytes()))?
+            .into_dictionary()
+            .ok_or(GDError::BadParse)?;
 
         let levels_dict = xmltree
-            .get("LLM_01")
-            .unwrap()
-            .to_owned()
+            .remove("LLM_01")
+            .ok_or(GDError::BadParse)?
             .into_dictionary()
-            .unwrap();
-        let llm_02 = xmltree.get("LLM_02").unwrap().to_owned();
-        let llm_03 = xmltree.get("LLM_03").unwrap().to_owned();
+            .ok_or(GDError::BadParse)?;
+        let llm_02 = xmltree.remove("LLM_02")
+            .ok_or(GDError::BadParse)?;
+        let llm_03 = xmltree.remove("LLM_03")
+            .ok_or(GDError::BadParse)?;
 
         // these are stored as "k_0": <level>, "k_1": <level>, etc. in the savefile,
         // the vec prserves that order.
-        let levels_parsed = levels_dict
-            .iter()
+        let collected_dicts = levels_dict
+            .into_iter()
             .filter_map(|(k, v)| match k.as_str() {
                 "_isArr" => None,
-                _ => Some(Level::from_dict(v.as_dictionary().unwrap().clone())),
+                _ => v.into_dictionary(),
             })
-            .collect::<Vec<Level>>();
+            .collect::<Vec<Dictionary>>();
+
+        #[cfg(feature = "parallel")]
+        let levels_parsed: Vec<Level> = collected_dicts
+            .into_par_iter()
+            .map(Level::from_dict)
+            .collect();
+
+        #[cfg(not(feature = "parallel"))]
+        let levels_parsed: Vec<Level> = collected_dicts
+            .into_iter()
+            .map(Level::from_dict)
+            .collect();
 
         let levels = Levels {
             levels: levels_parsed, // one of these might be for lists. will consider that later
             headers: LevelsFileHeaders {
-                llm02: llm_02,
-                llm03: llm_03,
+                llm_02,
+                llm_03,
             },
         };
 
@@ -124,13 +139,33 @@ impl Levels {
 
         let mut levels_dict = Dictionary::new();
         levels_dict.insert("_isArr".to_string(), Value::from(true));
-        for (idx, level) in self.levels.iter().enumerate() {
-            levels_dict.insert(format!("k_{idx}"), Value::from(level.to_dict()));
+        // for (idx, level) in self.levels.iter().enumerate() {
+        //     levels_dict.insert(format!("k_{idx}"), Value::from(level.to_dict()));
+        // }
+
+        #[cfg(feature = "parallel")]
+        let level_dict_entries = self
+            .levels
+            .par_iter()
+            .enumerate()
+            .map(|(idx, level)| (format!("k_{idx}"), Value::from(level.to_dict())))
+            .collect::<Vec<(String, Value)>>();
+
+        #[cfg(not(feature = "parallel"))]
+        let level_dict_entries = self
+            .levels
+            .iter()
+            .enumerate()
+            .map(|(idx, level)| (format!("k_{idx}"), Value::from(level.to_dict())))
+            .collect::<Vec<(String, Value)>>();
+
+        for (key, value) in level_dict_entries {
+            levels_dict.insert(key, value);
         }
 
         dict.insert("LLM_01".to_string(), plist::Value::Dictionary(levels_dict));
-        dict.insert("LLM_02".to_string(), self.headers.llm02.clone());
-        dict.insert("LLM_03".to_string(), self.headers.llm03.clone());
+        dict.insert("LLM_02".to_string(), self.headers.llm_02.clone());
+        dict.insert("LLM_03".to_string(), self.headers.llm_03.clone());
 
         format!(
             "<?xml version=\"1.0\"?><plist version=\"1.0\" gjver=\"2.0\">{}</plist>",
@@ -140,34 +175,37 @@ impl Levels {
 
     /// Exports this struct as encrypted XML to CCLocalLevels.dat
     pub fn export_to_savefile(&mut self) -> Result<(), GDError> {
-        let savefile = get_local_levels_path().unwrap();
-        let export_str = encrypt_savefile_str(self.export_to_string());
+        let savefile = get_local_levels_path()
+            .ok_or(GDError::NoAvailableSavefile)?;
+        let export_str = encrypt_savefile_str(&self.export_to_string());
         write(savefile, export_str)?;
         Ok(())
     }
 
     /// Exports this struct as encrypted XML to a given file
     pub fn export_to_file(&mut self, file: PathBuf) -> Result<(), GDError> {
-        let export_str = encrypt_savefile_str(self.export_to_string());
+        let export_str = encrypt_savefile_str(&self.export_to_string());
         write(file, export_str)?;
         Ok(())
     }
 
     /// Exports this struct as encrypted XML to CCLocalLevels.dat and creates a backup, CCLocalLevels.dat.bak
     pub fn export_to_savefile_with_backup(&mut self) -> Result<(), GDError> {
-        let savefile = get_local_levels_path().unwrap();
+        let savefile = get_local_levels_path()
+            .ok_or(GDError::NoAvailableSavefile)?;
         let backup_path = format!("{}.bak", savefile.to_string_lossy());
         write(backup_path, read(&savefile)?)?;
 
-        let export_str = encrypt_savefile_str(self.export_to_string());
+        let export_str = encrypt_savefile_str(&self.export_to_string());
         write(savefile, export_str)?;
         Ok(())
     }
 }
 
-#[inline(always)]
+/// Warning when using this fn: if the data isn't valid UTF8, the fn WILL panic!
+#[inline]
 fn vec_as_str(data: &[u8]) -> String {
-    String::from_utf8(data.to_vec()).unwrap()
+    core::str::from_utf8(data).unwrap().to_string()
 }
 
 /// This struct contains level-specific information
@@ -209,7 +247,7 @@ impl Level {
         Level {
             title: Some(title.into()),
             author: Some(author.into()),
-            description: description.map(|desc| b64_encode(desc.into().as_bytes().to_vec())),
+            description: description.map(|desc| b64_encode(desc.into().as_bytes())),
             data: Some(LevelState::Decrypted(LevelData {
                 headers: DEFAULT_LEVEL_HEADERS.to_string(),
                 objects: vec![],
@@ -220,11 +258,11 @@ impl Level {
     }
 
     /// Generates a hashmap with default level perties
+    #[must_use]
     pub fn default_properties() -> HashMap<String, Value> {
-        let mut ki6_dict = Dictionary::new();
-        for i in 0..15 {
-            ki6_dict.insert(format!("{i}"), Value::from("0"));
-        }
+        let ki6_dict: Dictionary = (0..15)
+            .map(|i| (i.to_string(), Value::from("0")))
+            .collect();
 
         // genuienly have no clue wht any of these are
         vec![
@@ -253,11 +291,10 @@ impl Level {
 
     /// Parses a .gmd file to a `Level` object
     pub fn from_gmd<T: Into<PathBuf>>(path: T) -> Result<Self, GDError> {
-        let file = proper_plist_tags(vec_as_str(&fs::read(path.into())?));
+        let file = proper_plist_tags(vec_as_str(&fs::read(path.into())?))?;
         let xmltree = Value::from_reader_xml(Cursor::new(file.as_bytes()))?
-            .as_dictionary_mut()
-            .unwrap()
-            .clone();
+            .into_dictionary()
+            .ok_or(GDError::BadParse)?;
 
         Ok(Level::from_dict(xmltree))
     }
@@ -291,7 +328,7 @@ impl Level {
         // residual properties
         let mut properties: HashMap<String, Value> = HashMap::new();
 
-        for (property, value) in d.into_iter() {
+        for (property, value) in d {
             match property.as_str() {
                 "k2" => title = Some(value.as_string().unwrap().to_owned()),
                 "k3" => description = Some(value.as_string().unwrap().to_owned()),
@@ -306,7 +343,7 @@ impl Level {
 
         let mut level_data: Option<LevelState> = None;
         if let Some(d) = data {
-            level_data = Some(LevelState::Encrypted(EncryptedLevelData { data: d }))
+            level_data = Some(LevelState::Encrypted(EncryptedLevelData { data: d }));
         }
 
         Level {
@@ -322,28 +359,28 @@ impl Level {
     /// Returns the level data as unencrypted.
     /// Level data is left unencrypted when parsing the level as it is slow.
     pub fn decrypt_level_data(&mut self) {
-        let raw_data = match &self.data {
+        let parsed = match &self.data {
             Some(data) => match data {
-                LevelState::Encrypted(encrypted) => encrypted.data.clone(),
+                LevelState::Encrypted(encrypted) => LevelData::parse(&encrypted.data),
                 LevelState::Decrypted(_) => return, // already decrypted
             },
             None => return, // no level data
         };
 
-        self.data = Some(LevelState::Decrypted(LevelData::parse(raw_data)));
+        self.data = Some(LevelState::Decrypted(parsed));
     }
 
     /// Returns the decrypted level data as a `LevelData` object if there is data.
     pub fn get_decrypted_data(&self) -> Option<LevelData> {
-        let raw_data = match self.data.clone() {
+        let parsed = match &self.data {
             Some(data) => match data {
-                LevelState::Encrypted(encrypted) => encrypted.data.clone(),
-                LevelState::Decrypted(d) => return Some(d), // already decrypted
+                LevelState::Encrypted(encrypted) => LevelData::parse(&encrypted.data),
+                LevelState::Decrypted(d) => return Some(d.clone()), // already decrypted
             },
             None => return None, // no level data
         };
 
-        Some(LevelData::parse(raw_data))
+        Some(parsed)
     }
 
     /// Returns the decrypted level data as a `LevelData` object if there is data.
@@ -362,36 +399,37 @@ impl Level {
     }
 
     /// Returns this object as a `plist::Dictionary`
+    #[must_use]
     pub fn to_dict(&self) -> Dictionary {
         let mut properties = Dictionary::new();
-        if let Some(v) = self.title.clone() {
-            properties.insert("k2".to_string(), Value::from(v));
-        };
-        if let Some(v) = self.description.clone() {
-            properties.insert("k3".to_string(), Value::from(v));
-        };
-        if let Some(v) = self.data.clone() {
+        if let Some(v) = self.title.as_ref() {
+            properties.insert("k2".to_string(), Value::from(v as &str));
+        }
+        if let Some(v) = self.description.as_ref() {
+            properties.insert("k3".to_string(), Value::from(v as &str));
+        }
+        if let Some(v) = self.data.as_ref() {
             let str = match v {
-                LevelState::Decrypted(data) => data.serialise_to_string(),
-                LevelState::Encrypted(data) => data.data,
+                LevelState::Decrypted(data) => &data.serialise_to_string(),
+                LevelState::Encrypted(data) => &data.data,
             };
-            properties.insert("k4".to_string(), Value::from(str));
-        };
-        if let Some(v) = self.author.clone() {
-            properties.insert("k5".to_string(), Value::from(v));
-        };
+            properties.insert("k4".to_string(), Value::from(str as &str));
+        }
+        if let Some(v) = self.author.as_ref() {
+            properties.insert("k5".to_string(), Value::from(v as &str));
+        }
         if let Some(v) = self.song {
             properties.insert("k45".to_string(), Value::from(v));
-        };
+        }
 
-        for (p, val) in self.properties.clone().into_iter() {
-            properties.insert(p, val);
+        for (p, val) in &self.properties {
+            properties.insert(p.clone(), val.clone());
         }
 
         properties
     }
 
-    /// Adds a GDObject to `self.objects`
+    /// Adds a `GDObject` to `self.objects`
     pub fn add_object(&mut self, object: GDObject) {
         if let Some(data) = &mut self.data {
             match data {
@@ -399,7 +437,7 @@ impl Level {
                     state.objects.push(object);
                 }
                 LevelState::Encrypted(_) => (),
-            };
+            }
         }
     }
 }
@@ -423,8 +461,7 @@ impl Display for Level {
                     .clone()
                     .unwrap_or("PE5vIGRlc2NyaXB0aW9uPg==".to_string())
                     .as_bytes()
-                    .to_vec()
-            )),
+            )?),
             self.author
                 .clone()
                 .unwrap_or("<Unknown author>".to_string()),
@@ -435,68 +472,125 @@ impl Display for Level {
 
 impl LevelData {
     /// Serialises this object to a string by serialising each subsequent component.
+    #[must_use]
     pub fn serialise_to_string(&self) -> String {
-        let objstr = self
+        #[cfg(feature = "parallel")]
+        let object_data = self
             .objects
-            .iter()
-            .map(|obj| obj.serialise_to_string())
+            .par_iter()
+            .map(GDObject::serialise_to_string)
             .collect::<Vec<String>>()
             .join("");
-        let unencrypted = format!("{};{objstr}", self.headers.clone());
-        vec_as_str(&encrypt_level_str(unencrypted))
+
+        #[cfg(not(feature = "parallel"))]
+        let object_data = {
+            let mut data = String::with_capacity(self.objects.len() * 64);
+            for obj in &self.objects {
+                data.push_str(&obj.serialise_to_string());
+            }
+            data
+        };
+
+        let mut unencrypted = String::with_capacity(self.headers.len() + object_data.len() + 1);
+        unencrypted.push_str(&self.headers);
+        unencrypted.push(';');
+        unencrypted.push_str(&object_data);
+
+        vec_as_str(&encrypt_level_str(&unencrypted))
     }
 
     /// Returns a list of all the groups that contain at least one object
+    #[must_use]
     pub fn get_used_groups(&self) -> Vec<Group> {
         if self.objects.is_empty() {
             return vec![];
         }
 
-        let mut groups = HashSet::new();
+        // let mut groups = HashSet::new();
+        #[cfg(feature = "parallel")]
+        let mut groups = self
+            .objects
+            .par_iter()
+            .flat_map_iter(|obj| obj.config.groups.iter())
+            .copied()
+            .collect::<Vec<Group>>();
 
-        for object in self.objects.iter() {
-            groups.extend(object.config.groups.iter());
-        }
-        let mut arr: Vec<Group> = groups.into_iter().collect();
-        arr.sort();
-        arr
+        #[cfg(not(feature = "parallel"))]
+        let mut groups = self
+            .objects
+            .iter()
+            .flat_map(|obj| obj.config.groups.iter())
+            .copied()
+            .collect::<Vec<Group>>();
+
+        groups.sort();
+        groups.dedup();
+        groups
     }
 
     /// Returns a list of all the groups that do not contain any objects
+    #[must_use]
     pub fn get_unused_groups(&self) -> Vec<Group> {
-        let all: BTreeSet<Group> = (1..10000).map(Group::Regular).collect();
-        let used: BTreeSet<Group> = self.get_used_groups().into_iter().collect();
+        // let all: BTreeSet<Group> = (1..10000).map(Group::Regular).collect();
+        // let used: BTreeSet<Group> = self.get_used_groups().into_iter().collect();
 
-        all.difference(&used).cloned().collect::<Vec<Group>>()
+        // all.difference(&used).cloned().collect::<Vec<Group>>()
+        let mut used: [bool; 10_000] = [false; 10_000];
+        for object in &self.objects {
+            for group in &object.config.groups {
+                if let Group::Regular(g) = group
+                    && (1..10_000).contains(g) {
+                    used[*g as usize] = true;
+                }
+            }
+        }
+
+        let mut unused: Vec<Group> = Vec::with_capacity(9_999);
+        for id in 1..10_000 {
+            if !used[id as usize] {
+                unused.push(Group::Regular(id));
+            }
+        }
+
+        unused
     }
 
     /// Returns a list of all groups used as arguments in triggers
+    #[must_use]
     pub fn get_argument_groups(&self) -> Vec<i16> {
         if self.objects.is_empty() {
             return vec![];
         }
 
-        // this should really be a const map, but that is impossible in the current version of rust.
-        // however, the performance cost is negligible since we only generate this list once per search.
-        let group_properties = PROPERTY_TABLE
-            .entries()
-            .filter_map(|(id, info)| {
-                if info.1 == GDObjPropType::Group {
-                    Some(*id)
-                } else {
-                    None
+        #[cfg(feature = "parallel")]
+        let mut groups = self
+            .objects
+            .par_iter()
+            .flat_map_iter(|object| {
+                let mut groups = Vec::new();
+                for p in GROUP_PROPERTY_IDS {
+                    if let Some(val) = object.get_property(*p) {
+                        match val {
+                            crate::gdobj::GDValue::Group(g) => groups.push(g),
+                            crate::gdobj::GDValue::GroupList(gs) => groups.extend(gs.iter().copied()),
+                            _ => {}
+                        }
+                    }
                 }
+                groups
             })
-            .collect::<Vec<u16>>();
+            .collect::<Vec<i16>>();
 
+        #[cfg(not(feature = "parallel"))]
         let mut groups = Vec::with_capacity(self.objects.len());
 
-        for object in self.objects.iter() {
-            for p in group_properties.iter() {
+        #[cfg(not(feature = "parallel"))]
+        for object in &self.objects {
+            for p in GROUP_PROPERTY_IDS {
                 if let Some(val) = object.get_property(*p) {
                     match val {
                         crate::gdobj::GDValue::Group(g) => groups.push(g),
-                        crate::gdobj::GDValue::GroupList(gs) => groups.extend(gs.to_vec()),
+                        crate::gdobj::GDValue::GroupList(gs) => groups.extend(gs.iter()),
                         _ => {}
                     }
                 }
@@ -509,20 +603,30 @@ impl LevelData {
     }
 
     /// Parse raw level data to this struct
-    pub fn parse(raw_data: String) -> Self {
+    #[must_use]
+    pub fn parse<T: AsRef<str>>(raw_data: T) -> Self {
+        let raw_data = raw_data.as_ref();
         // parse level data
         let raw_data = decompress(raw_data.as_bytes().to_vec()).unwrap();
         let decrypted = std::str::from_utf8(&raw_data[..]).unwrap();
-        let split = decrypted.split(";").collect::<Vec<&str>>();
+        
+        let split: Vec<&str> = decrypted.split(';').collect();
+        let headers = split.first().unwrap_or(&"").to_string();
+        let object_slice = split.get(1..).unwrap_or(&[]);
+        
+        #[cfg(feature = "parallel")]
+        let objects = object_slice
+            .par_iter()
+            .filter(|obj| obj.len() > 1)
+            .map(GDObject::parse_str)
+            .collect();
 
-        let headers = split[0].to_string();
-        let mut objects = Vec::with_capacity(split.len() - 1);
-
-        for object in &split[1..] {
-            if object.len() > 1 {
-                objects.push(GDObject::parse_str(object));
-            }
-        }
+        #[cfg(not(feature = "parallel"))]
+        let objects = object_slice
+            .iter()
+            .filter(|obj| obj.len() > 1)
+            .map(GDObject::parse_str)
+            .collect();
 
         LevelData { headers, objects }
     }

--- a/src/gdobj/defaults.rs
+++ b/src/gdobj/defaults.rs
@@ -1,7 +1,5 @@
 //! Default constructors for all objects
 
-use phf::{Map, phf_map};
-
 use crate::gdobj::GDObjConfig;
 
 use super::GDObject;
@@ -58,7 +56,7 @@ use super::GDObject;
 /// Maps object IDs to their default GD object strings (as the editor would produce them).  
 /// Sourced from HDanke's [default object strings](https://github.com/UHDanke/gmdkit/blob/main/src/gmdkit/defaults/objects.py)
 /// This map only stores the unique object strings that are not shared
-pub static OBJECT_DEFAULTS_UNIQUE: Map<i32, &'static str> = phf_map! {
+pub static OBJECT_DEFAULTS_UNIQUE: phf::Map<i32, &'static str> = phf::phf_map! {
     29i32 => "1,29,2,0,3,0,36,1,7,255,8,255,9,255,10,0.5,35,1,23,1000;",
     30i32 => "1,30,2,0,3,0,36,1,7,255,8,255,9,255,10,0.5,35,1,23,1001;",
     31i32 => "1,31,2,0,3,0,36,1,kA2,0,kA3,1,kA8,1,kA4,0,kA9,1,kA10,1,kA22,1,kA23,1,kA24,1,kA27,1,kA40,1,kA41,1,kA42,1,kA28,1,kA29,1,kA31,1,kA32,1,kA36,0,kA43,1,kA44,0,kA45,1,kA46,1,kA33,1,kA34,1,kA35,1,kA37,1,kA38,1,kA39,1,kA19,1,kA26,0,kA20,1,kA21,1,kA11,1;",
@@ -129,13 +127,14 @@ pub fn default_object(id: i32) -> GDObject {
     match OBJECT_DEFAULTS_UNIQUE.get(&id) {
         Some(s) => GDObject::parse_str(s),
         None => match check_common_suffix(id) {
-            Some(suf) => GDObject::parse_str(&format!("1,{id}{suf}")),
+            Some(suf) => GDObject::parse_str(format!("1,{id}{suf}")),
             None => GDObject::new(id, &GDObjConfig::default(), vec![]),
         },
     }
 }
 
 /// Returns the raw object string of a default object by ID.
+#[must_use]
 pub fn default_object_string(id: i32) -> String {
     match OBJECT_DEFAULTS_UNIQUE.get(&id) {
         Some(s) => s.to_string(),
@@ -149,7 +148,8 @@ pub fn default_object_string(id: i32) -> String {
 
 /// Returns a common suffix if a default object ID uses it.
 /// Example: IDs 1 through 9 all end with `,2,0,3,0;`
-pub fn check_common_suffix(id: i32) -> Option<&'static str> {
+#[must_use]
+pub const fn check_common_suffix(id: i32) -> Option<&'static str> {
     // this match statement is particularly messy, so line breaks are forced through comments
     // otherwise, rustfmt makes skyscrapers out of the match arms
     match id {

--- a/src/gdobj/lookup.rs
+++ b/src/gdobj/lookup.rs
@@ -245,6 +245,7 @@ pub static PROPERTY_TABLE: Map<u16, (&'static str, GDObjPropType)> = phf_map! {
 };
 
 /// Get type of a property by ID
+#[must_use]
 pub fn get_property_type(p: u16) -> Option<GDObjPropType> {
     PROPERTY_TABLE.get(&p).map(|v| v.1)
 }

--- a/src/gdobj/misc.rs
+++ b/src/gdobj/misc.rs
@@ -7,14 +7,14 @@ use crate::gdobj::{
     GDObjConfig, GDObject, GDValue,
     ids::{
         objects::{DEFAULT_BLOCK, TEXT_OBJECT},
-        properties::*,
+        properties::{BASE64ENCODED_TEXT, KERNING},
     },
 };
 
 /// Returns a default block object.
 /// # Arguments
 /// `config`: Object config
-#[inline(always)]
+#[inline]
 pub fn default_block(config: &GDObjConfig) -> GDObject {
     GDObject::new(DEFAULT_BLOCK, config, vec![])
 }
@@ -24,6 +24,7 @@ pub fn default_block(config: &GDObjConfig) -> GDObject {
 /// `config`: Object config
 /// `text`: Text in the objecty
 /// `kerning`: Spacing between chars. Default is 0
+#[inline]
 pub fn text<T: AsRef<str>>(config: &GDObjConfig, text: T, kerning: i32) -> GDObject {
     GDObject::new(
         TEXT_OBJECT,

--- a/src/gdobj/mod.rs
+++ b/src/gdobj/mod.rs
@@ -1,21 +1,12 @@
-//! This module contains the GDObject struct, used for parsing to/from raw object strings
-//! This module also contains the GDObjConfig struct for creating new GDObjects
+//! This module contains the `GDObject` struct, used for parsing to/from raw object strings
+//! This module also contains the `GDObjConfig` struct for creating new `GDObject`s
 use std::{
     fmt::{Debug, Display, Write},
     str::FromStr,
 };
 
 use crate::gdobj::{
-    ids::properties::{
-        CENTER_EFFECT, DONT_BOOST_X, DONT_BOOST_Y, DONT_ENTER, DONT_FADE, EDITOR_LAYER_1,
-        EDITOR_LAYER_2, ENTER_EFFECT_CHANNEL, EXTRA_STICKY, GRIP_SLOPE, GROUPS,
-        HAS_EXTENDED_COLLISION, HIDDEN, IS_AREA_PARENT, IS_GROUP_PARENT, IS_HIGH_DETAIL,
-        IS_ICE_BLOCK, MATERIAL_CONTROL_ID, MULTITRIGGERABLE, NO_AUDIO_SCALE, NO_GLOW,
-        NO_OBJECT_EFFECTS, NO_PARTICLES, NO_TOUCH, NONSTICK_X, NONSTICK_Y, OBJECT_COLOUR,
-        OBJECT_ID, OBJECT_MATERIAL, PARENT_GROUPS, PASSABLE, REVERSES_GAMEPLAY, ROTATION,
-        SCALE_STICK, SECONDARY_COLOUR, SINGLE_PLAYER_TOUCH, SPAWN_TRIGGERABLE, TOUCH_TRIGGERABLE,
-        X_POS, X_SCALE, Y_POS, Y_SCALE, Z_LAYER, Z_ORDER,
-    },
+    ids::properties::*,
     lookup::get_property_type,
 };
 use bitflags::bitflags;
@@ -115,6 +106,8 @@ pub enum Item {
 
 impl Item {
     /// Returns this item's type
+    #[inline]
+    #[must_use]
     pub fn get_type(&self) -> ItemType {
         match self {
             Self::Attempts => ItemType::Attempts,
@@ -124,12 +117,15 @@ impl Item {
             Self::Timer(_) => ItemType::Timer,
         }
     }
-    #[inline(always)]
     /// Returns this item's type as an i32
+    #[inline]
+    #[must_use]
     pub fn get_type_as_i32(&self) -> i32 {
         self.get_type() as i32
     }
     /// Returns this item's special mode if it has one
+    #[inline]
+    #[must_use]
     pub fn as_special_mode(&self) -> Option<CounterMode> {
         match self {
             Self::Attempts => Some(CounterMode::Attempts),
@@ -138,13 +134,16 @@ impl Item {
             _ => None,
         }
     }
-    #[inline(always)]
     /// Returns this item's special mode if it has one as an i32
-    pub fn as_special_mode_i32(&self) -> i32 {
-        self.as_special_mode().unwrap() as i32
+    #[inline]
+    #[must_use]
+    pub fn as_special_mode_i32(&self) -> Option<i32> {
+        self.as_special_mode().map(|m| m as i32)
     }
 
     /// Returns this item's ID
+    #[inline]
+    #[must_use]
     pub fn id(&self) -> i16 {
         match self {
             Self::Counter(c) => *c,
@@ -180,6 +179,7 @@ pub enum CounterMode {
 #[repr(u8)]
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Copy)]
 #[allow(missing_docs)]
+#[non_exhaustive]
 pub enum GDObjPropType {
     Int,
     Float,
@@ -342,6 +342,8 @@ const LIST_ALLOCSIZE: usize = 5;
 /// Enum for all values represented by Geometry Dash.
 /// All values are parsed according to their specified [`GDObjPropType`].
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+#[must_use]
 pub enum GDValue {
     /// Any 32-bit signed integer. Fallback for ints.
     Int(i32),
@@ -357,7 +359,7 @@ pub enum GDValue {
     Group(i16),
     /// Any item ID, whcih is represented by an `i16`.
     Item(i16),
-    /// A list of group IDs as i16, which is stored in a SmallVec.
+    /// A list of group IDs as i16, which is stored in a `SmallVec`.
     GroupList(smallvec::SmallVec<[i16; LIST_ALLOCSIZE]>),
     /// A list of probability pairs: (group id, relative chance). Used in the advanced random trigger
     ProbabilitiesList(smallvec::SmallVec<[(i16, i32); LIST_ALLOCSIZE]>),
@@ -375,10 +377,10 @@ pub enum GDValue {
     String(String), // fallback
 }
 
+/// Enum for all events that the event trigger can listen for
 #[repr(i32)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[allow(missing_docs)]
-/// Enum for all events that the event trigger can listen for
 pub enum Event {
     // zamn!! that's a lot of events
     Unknown = 0,
@@ -463,7 +465,7 @@ pub enum Event {
 }
 
 impl From<i32> for Event {
-    /// Converts the event ID to the variant of the [`Event`] enum. Default to TinyLanding.
+    /// Converts the event ID to the variant of the [`Event`] enum. Default to `TinyLanding`.
     fn from(i: i32) -> Self {
         match i {
             1 => Self::TinyLanding,
@@ -580,22 +582,14 @@ where
     T: Default + FromStr + Copy + Clone,
     S: Default + FromStr + Copy + Clone,
 {
-    let mut curr_group: T = T::default();
-    let mut idx = 0;
-    let mut tuples = vec![];
-    s.split('.').for_each(|c| {
-        match idx % 2 == 0 {
-            true => {
-                // at even idx, so this is a group
-                curr_group = parse!(c => T)
-            }
-            false => {
-                // at odd idx, so this is a chance
-                tuples.push((curr_group, parse!(c => S)));
-            }
-        };
-        idx += 1
-    });
+    let mut tuples = Vec::new();
+    let mut iter = s.split('.');
+    while let (Some(group), Some(chance)) = (iter.next(), iter.next()) {
+        let g = parse!(group => T);
+        let c = parse!(chance => S);
+        tuples.push((g, c));
+    }
+    
     tuples
 }
 
@@ -630,15 +624,15 @@ impl GDValue {
         }
     }
 
-    #[inline(always)]
     /// Converts a vector of [`Group`]s to a [`GDValue`]
-    pub fn from_group_list(g: Vec<Group>) -> Self {
+    #[inline]
+    pub fn from_group_list(g: &[Group]) -> Self {
         Self::GroupList(SmallVec::from_vec(g.iter().map(|&g| g.id()).collect()))
     }
 
-    #[inline(always)]
     /// Converts a vector of parent [`Group`]s to a [`GDValue`]
-    pub fn parents_group_list(g: Vec<Group>) -> Self {
+    #[inline]
+    pub fn parents_group_list(g: &[Group]) -> Self {
         Self::GroupList(SmallVec::from_vec(
             g.iter()
                 .filter_map(|g| match g {
@@ -649,26 +643,26 @@ impl GDValue {
         ))
     }
 
-    #[inline(always)]
     /// Converts a probabilities list to a [`GDValue`].
+    #[inline]
     pub fn from_prob_list(g: Vec<(i16, i32)>) -> Self {
         Self::ProbabilitiesList(SmallVec::from_vec(g))
     }
 
-    #[inline(always)]
     /// Converts a spawn remaps list to a [`GDValue`].
+    #[inline]
     pub fn from_spawn_remaps(g: Vec<(i16, i16)>) -> Self {
         Self::SpawnRemapsList(SmallVec::from_vec(g))
     }
 
-    #[inline(always)]
     /// Converts a raw colour channel value to a [`GDValue`].
+    #[inline]
     pub fn colour_channel(s: &str) -> Self {
         Self::ColourChannel(ColourChannel::from(s.parse().unwrap_or(0)))
     }
 
-    #[inline(always)]
     /// Converts a raw zlayer value to a [`GDValue`].
+    #[inline]
     pub fn zlayer(s: &str) -> Self {
         Self::ZLayer(ZLayer::from(s.parse().unwrap_or(0)))
     }
@@ -723,12 +717,14 @@ impl Display for GDValue {
             GDValue::ColourChannel(v) => write!(f, "{}", i_buf.format(Into::<i16>::into(*v))),
             GDValue::Easing(v) => write!(f, "{}", i_buf.format(*v as i32)),
             GDValue::Float(v) => write!(f, "{}", d_buf.format(*v)),
-            GDValue::Group(v) | GDValue::Item(v) => write!(f, "{}", i_buf.format(*v)),
+            GDValue::Group(v) 
+                | GDValue::Item(v)
+                | GDValue::Short(v)
+                => write!(f, "{}", i_buf.format(*v)),
             GDValue::GroupList(v) => write!(f, "{}", fmt_intlist!(v, i_buf)),
             GDValue::ProbabilitiesList(v) => write!(f, "{}", fmt_inttuples!(v, i_buf)),
             GDValue::SpawnRemapsList(v) => write!(f, "{}", fmt_inttuples!(v, i_buf)),
             GDValue::Int(v) => write!(f, "{}", i_buf.format(*v)),
-            GDValue::Short(v) => write!(f, "{}", i_buf.format(*v)),
             GDValue::String(v) => write!(f, "{v}"),
             GDValue::ZLayer(v) => write!(f, "{}", i_buf.format(*v as i32)),
             GDValue::Events(evts) => write!(f, "{}", fmt_intlist!(evts, i_buf)),
@@ -867,6 +863,7 @@ const OBJECT_NAMES: &[(i32, &str)] = &[
 
 /// Container for GD Object properties.
 #[derive(Clone, PartialEq)]
+#[must_use]
 pub struct GDObject {
     /// The object's ID.
     pub id: i32,
@@ -878,28 +875,26 @@ pub struct GDObject {
 
 impl Display for GDObject {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let group_str = match !self.config.groups.is_empty() {
-            true => &format!(
-                " with groups: {}",
-                self.config
-                    .groups
-                    .iter()
-                    .map(|g| format!("{}", g.id()))
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            ),
-            false => "",
-        };
+        let mut group_str = String::new();
+        if !self.config.groups.is_empty() {
+            group_str += " with groups: ";
+            for (idx, g) in self.config.groups.iter().enumerate() {
+                if idx != 0 {
+                    group_str.push_str(", ");
+                }
+                let _ = write!(group_str, "{}", g.id());
+            }
+        }
 
         let mut trigger_conf_str = String::new();
         if self.config.trigger_cfg.spawnable || self.config.trigger_cfg.touchable {
             if self.config.trigger_cfg.multitriggerable {
-                trigger_conf_str += "Multi"
+                trigger_conf_str += "Multi";
             }
             if self.config.trigger_cfg.touchable {
-                trigger_conf_str += "touchable "
+                trigger_conf_str += "touchable ";
             } else if self.config.trigger_cfg.spawnable {
-                trigger_conf_str += "spawnable "
+                trigger_conf_str += "spawnable ";
             }
         }
 
@@ -921,7 +916,7 @@ impl Debug for GDObject {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut property_str = String::with_capacity(self.properties.len() * 32);
 
-        for (property, value) in self.properties.iter() {
+        for (property, value) in &self.properties {
             let desc = lookup::PROPERTY_TABLE.get(property).map(|p| p.0);
             if let Some(d) = desc {
                 write!(property_str, "\n    - {d}: {value:?}")
@@ -940,15 +935,16 @@ impl Debug for GDObject {
 }
 
 impl GDObject {
-    /// Parses raw object string to GDObject
-    pub fn parse_str(s: &str) -> GDObject {
+    /// Parses raw object string to `GDObject`
+    pub fn parse_str<T: AsRef<str>>(s: T) -> GDObject {
+        let s = s.as_ref();
         let mut obj = GDObject {
             id: 1,
             config: GDObjConfig::default(),
             properties: vec![],
         };
 
-        let mut iter = s.trim_end_matches(';').split(",");
+        let mut iter = s.trim_end_matches(';').split(',');
         while let (Some(idx), Some(val)) = (iter.next(), iter.next()) {
             let idx_u16 = match idx.parse::<u16>() {
                 Ok(n) => n,
@@ -969,7 +965,7 @@ impl GDObject {
                 GROUPS => {
                     obj.config.add_groups(
                         val.trim_matches('"')
-                            .split(".")
+                            .split('.')
                             .filter_map(|g| g.parse::<i16>().ok())
                             .map(Group::Regular)
                             .collect::<Vec<Group>>(),
@@ -980,10 +976,10 @@ impl GDObject {
                 EDITOR_LAYER_1 => obj.config.editor_layers.0 = parse!(val => i16),
                 EDITOR_LAYER_2 => obj.config.editor_layers.1 = parse!(val => i16),
                 OBJECT_COLOUR => {
-                    obj.config.colour_channels.0 = ColourChannel::from(parse!(val => i16))
+                    obj.config.colour_channels.0 = ColourChannel::from(parse!(val => i16));
                 }
                 SECONDARY_COLOUR => {
-                    obj.config.colour_channels.1 = ColourChannel::from(parse!(val => i16))
+                    obj.config.colour_channels.1 = ColourChannel::from(parse!(val => i16));
                 }
                 Z_LAYER => obj.config.z_layer = ZLayer::from(parse!(val => i32)),
                 Z_ORDER => obj.config.z_order = parse!(val => i32),
@@ -1090,7 +1086,7 @@ impl GDObject {
                     // add groups method handles deduping
                     obj.config.add_groups(
                         val.trim_matches('"')
-                            .split(".")
+                            .split('.')
                             .filter_map(|g| g.parse::<i16>().ok())
                             .map(Group::Parent)
                             .collect::<Vec<Group>>(),
@@ -1115,11 +1111,9 @@ impl GDObject {
 
     /// Sets the prpoerty ID to the value, and craetes it if it doesn't exist
     pub fn set_property(&mut self, p: u16, val: GDValue) {
-        if let Some(v) = self.properties.iter_mut().find(|(k, _)| *k == p) {
-            v.1 = val;
-        } else {
-            let new_idx = self.properties.partition_point(|(k, _)| k < &p);
-            self.properties.insert(new_idx, (p, val));
+        match self.properties.binary_search_by_key(&p, |t| t.0) {
+            Ok(idx) => self.properties[idx].1 = val,
+            Err(idx) => self.properties.insert(idx, (p, val)),
         }
     }
 
@@ -1131,9 +1125,10 @@ impl GDObject {
     }
 
     /// Returns this object as a property string
+    #[must_use]
     pub fn serialise_to_string(&self) -> String {
         let mut properties_string = String::with_capacity(self.properties.len() * 8);
-        for (idx, val) in self.properties.iter() {
+        for (idx, val) in &self.properties {
             let (pref, id) = if *idx < 10_000 {
                 ("", *idx)
             } else {
@@ -1144,22 +1139,24 @@ impl GDObject {
         }
         let config_str = self.config.serialise_to_string();
 
-        let raw_str = format!("1,{}{config_str}{properties_string}", self.id);
-        raw_str.replace("\"", "") + ";"
+        let mut raw_str = format!("1,{}{config_str}{properties_string}", self.id);
+        raw_str.retain(|c| c != '"');
+        raw_str.push(';');
+        raw_str
     }
 
     /// Returns this object's name
+    #[inline]
+    #[must_use]
     pub fn get_name(&self) -> String {
-        OBJECT_NAMES
-            .iter()
-            .find(|&o| o.0 == self.id)
-            .unwrap_or(&(0, format!("Object {}", self.id).as_str()))
-            .1
-            .to_string()
+        match OBJECT_NAMES.iter().find(|(id, _)| *id == self.id) {
+            Some((_, name)) => name.to_string(),
+            None => format!("Object {}", self.id),
+        }
     }
 
-    /// Creates a new GDObject from ID, config, and extra proerties
-    #[inline(always)]
+    /// Creates a new `GDObject` from ID, config, and extra proerties
+    #[inline]
     pub fn new(id: i32, config: &GDObjConfig, properties: Vec<(u16, GDValue)>) -> Self {
         GDObject {
             id,
@@ -1174,12 +1171,13 @@ impl GDObject {
         defaults::default_object(id)
     }
 
-    #[inline(always)]
+    #[inline]
     fn get_attr_as_gdvalue(&self, attr: GDObjAttributes) -> GDValue {
         GDValue::Bool(self.config.get_attribute_flag(attr))
     }
 
     /// Fetches a property from this object's configuration
+    #[must_use]
     pub fn get_property(&self, p: u16) -> Option<GDValue> {
         match p {
             // one of the most fascinating matches of all time
@@ -1188,7 +1186,7 @@ impl GDObject {
             3 => Some(GDValue::Float(self.config.pos.1)),
             6 => Some(GDValue::Float(self.config.angle)),
             11 => Some(GDValue::Bool(self.config.trigger_cfg.touchable)),
-            57 => Some(GDValue::from_group_list(self.config.groups.clone())),
+            57 => Some(GDValue::from_group_list(&self.config.groups)),
             62 => Some(GDValue::Bool(self.config.trigger_cfg.spawnable)),
             87 => Some(GDValue::Bool(self.config.trigger_cfg.multitriggerable)),
             128 => Some(GDValue::Float(self.config.scale.0)),
@@ -1229,9 +1227,9 @@ impl GDObject {
 
             _ => self
                 .properties
-                .iter()
-                .find(|pair| pair.0 == p)
-                .map(|p| p.1.clone()),
+                .binary_search_by_key(&p, |(key, _)| *key)
+                .ok()
+                .map(|idx| self.properties[idx].1.clone()),
         }
     }
 
@@ -1242,7 +1240,7 @@ impl GDObject {
 }
 
 /// Trigger config, used for defining general properties of a trigger object
-#[derive(Clone, Debug, PartialEq, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub struct TriggerConfig {
     /// is touch triggerable?
     pub touchable: bool,
@@ -1261,18 +1259,18 @@ pub enum Group {
 }
 
 impl Ord for Group {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         // check ids first
         // check the types only if equal
         match self.id().cmp(&other.id()) {
-            std::cmp::Ordering::Equal => self.get_type().cmp(&other.get_type()),
+            core::cmp::Ordering::Equal => self.as_type().cmp(&other.as_type()),
             o => o,
         }
     }
 }
 
 impl PartialOrd for Group {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
@@ -1286,34 +1284,35 @@ pub enum GroupType {
 }
 
 impl Ord for GroupType {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         if self == other {
-            std::cmp::Ordering::Equal
+            core::cmp::Ordering::Equal
         } else if *self == Self::Regular {
             // other is parent, so is less
-            std::cmp::Ordering::Greater
+            core::cmp::Ordering::Greater
         } else {
-            std::cmp::Ordering::Less
+            core::cmp::Ordering::Less
         }
     }
 }
 
 impl PartialOrd for GroupType {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
 
 impl Group {
     /// Returns this group's ID
+    #[must_use]
     pub fn id(&self) -> i16 {
         match self {
-            Self::Regular(id) => *id,
-            Self::Parent(id) => *id,
+            Self::Regular(id) | Self::Parent(id) => *id,
         }
     }
     /// Returns this group's type
-    pub fn get_type(&self) -> GroupType {
+    #[must_use]
+    pub fn as_type(&self) -> GroupType {
         match self {
             Group::Parent(_) => GroupType::Parent,
             Group::Regular(_) => GroupType::Regular,
@@ -1329,6 +1328,7 @@ impl From<i16> for Group {
 
 /// Object config, used for defining general properties of an object
 #[derive(Clone, Debug, PartialEq)]
+#[must_use]
 pub struct GDObjConfig {
     /// Position of this object
     pub pos: (f64, f64),
@@ -1384,12 +1384,13 @@ impl Default for GDObjConfig {
 
 impl GDObjConfig {
     /// Alias for default
-    #[inline(always)]
+    #[inline]
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Serialises this config struct to a string
+    #[must_use]
     pub fn serialise_to_string(&self) -> String {
         let mut properties = String::with_capacity(64);
         let _ = write!(
@@ -1443,14 +1444,14 @@ impl GDObjConfig {
 
         if !self.groups.is_empty() {
             properties.push_str(",57,");
-            let group_str = &self
-                .groups
-                .iter()
-                .map(|g| g.id().to_string())
-                .collect::<Vec<String>>()
-                .join(".");
-            properties.push_str(group_str);
-        };
+            let mut i_buf = itoa::Buffer::new();
+            for (idx, group) in self.groups.iter().enumerate() {
+                if idx != 0 {
+                    properties.push('.');
+                }
+                properties.push_str(i_buf.format(group.id()));
+            }
+        }
 
         properties
     }
@@ -1462,50 +1463,51 @@ impl GDObjConfig {
     }
 
     /// Sets groups of this object
-    #[inline(always)]
+    #[inline]
     pub fn groups<T: IntoIterator<Item = I>, I: Into<Group>>(mut self, groups: T) -> Self {
-        self.groups = groups.into_iter().map(|g| g.into()).collect();
+        self.groups = groups.into_iter().map(std::convert::Into::into).collect();
         self.dedup_groups();
         self
     }
     /// Adds groups to this object's groups
-    #[inline(always)]
+    #[inline]
     pub fn add_groups<T: AsRef<[Group]>>(&mut self, groups: T) {
         self.groups.extend_from_slice(groups.as_ref());
         self.dedup_groups();
     }
     /// Adds group to this object's groups
-    #[inline(always)]
+    #[inline]
     pub fn add_group(&mut self, group: Group) {
         self.groups.push(group);
         self.dedup_groups();
     }
     /// Removes this group from this object's groups
-    #[inline(always)]
+    #[inline]
     pub fn remove_group(&mut self, group: Group) {
         if let Some(idx) = self.groups.iter().position(|&g| g == group) {
             self.groups.swap_remove(idx);
         }
     }
     /// Clears all groups from this object
-    #[inline(always)]
+    #[inline]
     pub fn clear_groups(&mut self) {
         self.groups.clear();
     }
     /// Sets x position of this object
-    #[inline(always)]
+    #[inline]
     pub fn x(mut self, x: f64) -> Self {
         self.pos.0 = x;
         self
     }
     /// Sets y position of this object
-    #[inline(always)]
+    #[inline]
     pub fn y(mut self, y: f64) -> Self {
         self.pos.1 = y;
         self
     }
 
     /// Applies a translation to this object's position
+    #[inline]
     pub fn translate(mut self, x: f64, y: f64) -> Self {
         self.pos.0 += x;
         self.pos.1 += y;
@@ -1513,103 +1515,103 @@ impl GDObjConfig {
     }
 
     /// Sets x and y position of this object
-    #[inline(always)]
+    #[inline]
     pub fn pos(mut self, x: f64, y: f64) -> Self {
         self.pos = (x, y);
         self
     }
     /// Sets x scale of this object
-    #[inline(always)]
+    #[inline]
     pub fn xscale(mut self, xscale: f64) -> Self {
         self.scale.0 = xscale;
         self
     }
     /// Sets y scale of this object
-    #[inline(always)]
+    #[inline]
     pub fn yscale(mut self, yscale: f64) -> Self {
         self.scale.1 = yscale;
         self
     }
     /// Sets x and y scale of this object
-    #[inline(always)]
+    #[inline]
     pub fn scale(mut self, x: f64, y: f64) -> Self {
         self.scale = (x, y);
         self
     }
     /// Sets rotation angle of this object
-    #[inline(always)]
+    #[inline]
     pub fn angle(mut self, angle: f64) -> Self {
         self.angle = angle;
         self
     }
     /// Makes this object touch triggerable
-    #[inline(always)]
+    #[inline]
     pub fn touchable(mut self, touchable: bool) -> Self {
         self.trigger_cfg.touchable = touchable;
         self
     }
     /// Makes this object spawn triggerable
-    #[inline(always)]
+    #[inline]
     pub fn spawnable(mut self, spawnable: bool) -> Self {
         self.trigger_cfg.spawnable = spawnable;
         self
     }
     /// Makes this object multi-triggerable
-    #[inline(always)]
+    #[inline]
     pub fn multitrigger(mut self, multi: bool) -> Self {
         self.trigger_cfg.multitriggerable = multi;
         self
     }
     /// Sets this object's base colour channel
-    #[inline(always)]
+    #[inline]
     pub fn set_base_colour(mut self, channel: ColourChannel) -> Self {
         self.colour_channels.0 = channel;
         self
     }
     /// Sets this object's detail colour channel
-    #[inline(always)]
+    #[inline]
     pub fn set_detail_colour(mut self, channel: ColourChannel) -> Self {
         self.colour_channels.1 = channel;
         self
     }
     /// Sets this object's Z-layer
-    #[inline(always)]
+    #[inline]
     pub fn set_z_layer(mut self, z: ZLayer) -> Self {
         self.z_layer = z;
         self
     }
     /// Sets this object's Z-order
-    #[inline(always)]
+    #[inline]
     pub fn set_z_order(mut self, z: i32) -> Self {
         self.z_order = z;
         self
     }
     /// Sets editor layer 1 of this object
-    #[inline(always)]
+    #[inline]
     pub fn editor_layer_1(mut self, l: i16) -> Self {
         self.editor_layers.0 = l;
         self
     }
     /// Sets editor layer 2 of this object
-    #[inline(always)]
+    #[inline]
     pub fn editor_layer_2(mut self, l: i16) -> Self {
         self.editor_layers.1 = l;
         self
     }
     /// Sets this object's material id
-    #[inline(always)]
+    #[inline]
     pub fn set_material_id(mut self, material_id: i16) -> Self {
         self.material_id = material_id;
         self
     }
     /// Sets this object's enter effect channel
-    #[inline(always)]
+    #[inline]
     pub fn set_enter_channel(mut self, channel: i16) -> Self {
         self.enter_effect_channel = channel;
         self
     }
     /// Sets this object's control ID
-    #[inline(always)]
+    #[inline]
     pub fn set_control_id(mut self, id: i16) -> Self {
         self.control_id = id;
         self
@@ -1617,11 +1619,14 @@ impl GDObjConfig {
 
     /// Gets the value of a set attribute flag.  
     /// The flag is only true if it has been set as such. Unset flags return false.
+    #[inline]
+    #[must_use]
     pub fn get_attribute_flag(&self, flag: GDObjAttributes) -> bool {
         self.attributes.contains(flag)
     }
 
     /// Sets the attribute of the specified flag. Function is useable in builder syntax.
+    #[inline]
     pub fn set_attribute_flag(mut self, flag: GDObjAttributes, toggle: bool) -> Self {
         self.attributes.set(flag, toggle);
         self
@@ -1629,9 +1634,9 @@ impl GDObjConfig {
 }
 
 bitflags! {
-    /// Common attributes container struct
-    #[derive(Debug, Clone, PartialEq, Default, Eq, Hash)]
-    // #[allow(missing_docs)] won't work here for some odd reason
+    #[allow(missing_docs)]
+    #[derive(Debug, Clone, Copy, PartialEq, Default, Eq, Hash)]
+    #[must_use]
     pub struct GDObjAttributes: u32 {
         /// @nodoc
         const dont_fade          = 1;
@@ -1683,49 +1688,52 @@ bitflags! {
         const reverse            = 1 << 23;
     }
 }
+const GD_OBJ_ATTR_FIELDS: &[(u16, GDObjAttributes)] = &[
+    (DONT_FADE, GDObjAttributes::dont_fade),
+    (DONT_ENTER, GDObjAttributes::dont_enter),
+    (NO_OBJECT_EFFECTS, GDObjAttributes::no_effects),
+    (IS_GROUP_PARENT, GDObjAttributes::is_group_parent),
+    (IS_AREA_PARENT, GDObjAttributes::is_area_parent),
+    (DONT_BOOST_X, GDObjAttributes::dont_boost_x),
+    (DONT_BOOST_Y, GDObjAttributes::dont_boost_y),
+    (IS_HIGH_DETAIL, GDObjAttributes::high_detail),
+    (NO_TOUCH, GDObjAttributes::no_touch),
+    (PASSABLE, GDObjAttributes::passable),
+    (HIDDEN, GDObjAttributes::hidden),
+    (NONSTICK_X, GDObjAttributes::non_stick_x),
+    (NONSTICK_Y, GDObjAttributes::non_stick_y),
+    (EXTRA_STICKY, GDObjAttributes::extra_sticky),
+    (HAS_EXTENDED_COLLISION, GDObjAttributes::extended_collision),
+    (IS_ICE_BLOCK, GDObjAttributes::is_ice_block),
+    (GRIP_SLOPE, GDObjAttributes::grip_slope),
+    (NO_GLOW, GDObjAttributes::no_glow),
+    (NO_PARTICLES, GDObjAttributes::no_particles),
+    (SCALE_STICK, GDObjAttributes::scale_stick),
+    (NO_AUDIO_SCALE, GDObjAttributes::no_audio_scale),
+    (SINGLE_PLAYER_TOUCH, GDObjAttributes::single_ptouch),
+    (CENTER_EFFECT, GDObjAttributes::center_effect),
+    (REVERSES_GAMEPLAY, GDObjAttributes::reverse),
+];
 
 impl GDObjAttributes {
-    #[inline(always)]
+    #[inline]
     /// Makes a default instance of this object
     pub fn new() -> Self {
         Self::default()
     }
 
     /// Serialises this object to a string
+    #[inline]
+    #[must_use]
     pub fn get_property_str(&self) -> String {
-        let fields = [
-            (DONT_FADE, Self::dont_fade),
-            (DONT_ENTER, Self::dont_enter),
-            (NO_OBJECT_EFFECTS, Self::no_effects),
-            (IS_GROUP_PARENT, Self::is_group_parent),
-            (IS_AREA_PARENT, Self::is_area_parent),
-            (DONT_BOOST_X, Self::dont_boost_x),
-            (DONT_BOOST_Y, Self::dont_boost_y),
-            (IS_HIGH_DETAIL, Self::high_detail),
-            (NO_TOUCH, Self::no_touch),
-            (PASSABLE, Self::passable),
-            (HIDDEN, Self::hidden),
-            (NONSTICK_X, Self::non_stick_x),
-            (NONSTICK_Y, Self::non_stick_y),
-            (EXTRA_STICKY, Self::extra_sticky),
-            (HAS_EXTENDED_COLLISION, Self::extended_collision),
-            (IS_ICE_BLOCK, Self::is_ice_block),
-            (GRIP_SLOPE, Self::grip_slope),
-            (NO_GLOW, Self::no_glow),
-            (NO_PARTICLES, Self::no_particles),
-            (SCALE_STICK, Self::scale_stick),
-            (NO_AUDIO_SCALE, Self::no_audio_scale),
-            (SINGLE_PLAYER_TOUCH, Self::single_ptouch),
-            (CENTER_EFFECT, Self::center_effect),
-            (REVERSES_GAMEPLAY, Self::reverse),
-        ];
-        let mut properties_str = String::with_capacity(6 * fields.len());
+        let mut properties_str = String::with_capacity(6 * GD_OBJ_ATTR_FIELDS.len());
 
-        for (id, flag) in fields {
-            if self.contains(flag) {
+        for (id, flag) in GD_OBJ_ATTR_FIELDS {
+            if self.contains(*flag) {
                 let _ = write!(properties_str, ",{id},1");
             }
         }
+
         properties_str
     }
 }

--- a/src/gdobj/triggers.rs
+++ b/src/gdobj/triggers.rs
@@ -9,61 +9,8 @@ use anyhow::anyhow;
 use crate::gdobj::{
     Anim, ColourChannel, Event, GDObjConfig, GDObject, GDValue, Item, MoveEasing,
     ids::{
-        objects::{
-            BG_EFFECT_OFF, BG_EFFECT_ON, BG_SPEED_CONFIG, CAMERA_GUIDE, COLLISION_BLOCK,
-            COLLISION_STATE_BLOCK, COUNTER, DISABLE_PLAYER_TRAIL, ENABLE_PLAYER_TRAIL,
-            MG_SPEED_CONFIG, START_POS, TOGGLE_BLOCK, TRIGGER_ADVANCED_RANDOM, TRIGGER_ANIMATE,
-            TRIGGER_AREA_STOP, TRIGGER_CAMERA_ZOOM, TRIGGER_COLLISION, TRIGGER_COLOUR,
-            TRIGGER_COUNT, TRIGGER_END, TRIGGER_EVENT, TRIGGER_FOLLOW, TRIGGER_FOLLOW_PLAYER_Y,
-            TRIGGER_GRAVITY, TRIGGER_ITEM_COMPARE, TRIGGER_ITEM_EDIT, TRIGGER_LINK_VISIBLE,
-            TRIGGER_MIDDLEGROUND_CHANGE, TRIGGER_MIDDLEGROUND_CONFIG, TRIGGER_MOVE,
-            TRIGGER_ON_DEATH, TRIGGER_PERSISTENT_ITEM, TRIGGER_PLAYER_CONTROL, TRIGGER_PULSE,
-            TRIGGER_RANDOM, TRIGGER_RESET_GROUP, TRIGGER_REVERSE_GAMEPLAY, TRIGGER_ROTATION,
-            TRIGGER_SCALE, TRIGGER_SHAKE, TRIGGER_SPAWN, TRIGGER_SPAWN_PARTICLE, TRIGGER_STOP,
-            TRIGGER_TIME, TRIGGER_TIME_CONTROL, TRIGGER_TIME_EVENT, TRIGGER_TIME_WARP,
-            TRIGGER_TOGGLE, TRIGGER_TOUCH, UI_CONFIG,
-        },
-        properties::{
-            ACTIVATE_GROUP, ANIMATION_ID, BLENDING_ENABLED, BLUE, CAMERA_GUIDE_PREVIEW_OPACITY,
-            CAMERA_ZOOM, CENTER_GROUP_ID, CLAIM_TOUCH, COLOUR_CHANNEL, COMPARE_OPERATOR,
-            CONTROLLING_PLAYER_1, CONTROLLING_PLAYER_2, CONTROLLING_TARGET_PLAYER,
-            COPY_COLOUR_FROM_CHANNEL, COPY_COLOUR_SPECS, COPY_OPACITY, COUNTER_ALIGNMENT,
-            DIRECTIONAL_MODE_DISTANCE, DIRECTIONAL_MOVE_MODE, DISABLE_PREVIEW, DIV_BY_VALUE_X,
-            DIV_BY_VALUE_Y, DONT_OVERRIDE, DURATION_GROUP_TRIGGER_CHANCE, DYNAMIC_BLOCK,
-            DYNAMIC_MOVE, EASING_RATE, ENTEREXIT_TRANSITION_CONFIG, EVENT_EXTRA_ID,
-            EVENT_EXTRA_ID_2, EVENT_LISTENERS, EXCLUSIVE_PULSE_MODE, FIRST_ITEM_TYPE,
-            FOLLOW_CAMERAS_X_MOVEMENT, FOLLOW_CAMERAS_Y_MOVEMENT, FOLLOW_DELAY, FOLLOW_OFFSET,
-            FOLLOW_PLAYERS_X_MOVEMENT, FOLLOW_PLAYERS_Y_MOVEMENT, FOLLOW_SPEED, GRAVITY, GREEN,
-            IGNORE_TIMEWARP, INPUT_ITEM_1, INPUT_ITEM_2, INSTANT_END, IS_DISABLED, IS_INTERACTABLE,
-            IS_TIMER, LEFT_OPERATOR, LEFT_ROUND_MODE, LEFT_SIGN_MODE, LOCK_OBJECT_ROTATION,
-            MATCH_ROTATION_OF_SPAWNED_PARTICLES, MAX_FOLLOW_SPEED, MAXX_ID, MAXY_ID, MIDDLEGROUND,
-            MINX_ID, MINY_ID, MODIFIER, MOVE_EASING, MOVE_UNITS_X, MOVE_UNITS_Y, MULTI_ACTIVATE,
-            MULTIACTIVATABLE_TIME_EVENT, NEW_X_SCALE, NEW_Y_SCALE, NO_END_EFFECTS,
-            NO_END_SOUND_EFFECTS, NO_LEGACY_HSV, ONLY_MOVE, OPACITY, PAUSE_AT_TARGET_TIME,
-            PULSE_DETAIL_COLOUR_ONLY, PULSE_FADE_IN_TIME, PULSE_FADE_OUT_TIME, PULSE_GROUP,
-            PULSE_HOLD_TIME, PULSE_MAIN_COLOUR_ONLY, RANDOM_PROBABILITIES_LIST, RED,
-            RELATIVE_ROTATION, RELATIVE_SCALE, RESET_CAMERA, RESET_ITEM_TO_0, RESET_REMAP,
-            REVERSE_GAMEPLAY, RIGHT_OPERATOR, RIGHT_ROUND_MODE, RIGHT_SIGN_MODE, ROTATE_DEGREES,
-            ROTATE_GAMEPLAY, ROTATE_X360, ROTATION_OF_SPAWNED_PARTICLES, ROTATION_OFFSET,
-            ROTATION_TARGET_ID, ROTATION_VARIATION_OF_SPAWNED_PARTICLES,
-            SCALE_OF_SPAWNED_PARTICLES, SCALE_VARIATION_OF_SPAWNED_PARTICLES, SECOND_ITEM_TYPE,
-            SECOND_MODIFIER, SECONDS_ONLY, SET_PERSISTENT_ITEM, SHAKE_INTERVAL, SHAKE_STRENGTH,
-            SILENT_MOVE, SMALL_STEP, SPAWN_DELAY, SPAWN_DELAY_VARIATION, SPAWN_ID_REMAPS,
-            SPAWN_ONLY, SPAWN_ORDERED, SPECIAL_COUNTER_MODE, START_PAUSED_TIMER, START_TIME,
-            STARTING_GAMEMODE, STARTING_IN_DUAL_MODE, STARTING_IN_MINI_MODE,
-            STARTING_IN_MIRROR_MODE, STARTING_SPEED, STOP_MODE, STOP_PLAYER_JUMP,
-            STOP_PLAYER_MOVEMENT, STOP_PLAYER_ROTATION, STOP_PLAYER_SLIDING, STOP_TIME_COUNTER,
-            TARGET_ALL_PERSISTENT_ITEMS, TARGET_CHANNEL, TARGET_COUNT, TARGET_ITEM, TARGET_ITEM_2,
-            TARGET_ITEM_TYPE, TARGET_MOVE_MODE, TARGET_MOVE_MODE_AXIS_LOCK, TARGET_ORDER,
-            TARGET_TIME, TARGET_TRANSITION_CHANNEL, TIME_VALUE_MULTIPLER, TIMER, TIMEWARP_AMOUNT,
-            TOLERANCE, TOUCH_DUAL_MODE, TOUCH_HOLD_MODE, TOUCH_PLAYER_ONLY, TOUCH_TOGGLE_ONOFF,
-            TRIGGER_ON_EXIT, USE_CONTROL_ID, USING_PLAYER_COLOUR_1, USING_PLAYER_COLOUR_2,
-            X_MOVEMENT_MULTIPLIER, X_OFFSET_OF_SPAWNED_PARTICLES,
-            X_OFFSET_VARIATION_OF_SPAWNED_PARTICLES, X_REFERENCE_IS_RELATIVE, X_REFERENCE_POSITION,
-            XAXIS_FOLLOW_MOD, Y_MOVEMENT_MULTIPLIER, Y_OFFSET_OF_SPAWNED_PARTICLES,
-            Y_OFFSET_VARIATION_OF_SPAWNED_PARTICLES, Y_REFERENCE_IS_RELATIVE, Y_REFERENCE_POSITION,
-            YAXIS_FOLLOW_MOD,
-        },
+        objects::*,
+        properties::*,
     },
 };
 
@@ -182,6 +129,7 @@ pub enum CompareOp {
 
 /// Compare operand configuration specifier for the item control trigger
 #[derive(Debug, Clone, Copy, PartialEq)]
+#[must_use]
 pub struct CompareOperand {
     /// Base item whose value is being used for the comparsion
     pub operand_item: Item,
@@ -419,6 +367,7 @@ pub struct Colour {
 
 impl Colour {
     /// Converts an RGB tuple to a [`Colour`]
+    #[must_use]
     pub fn from_rgb(rgb: (u8, u8, u8)) -> Self {
         Self {
             red: rgb.0,
@@ -548,6 +497,7 @@ pub struct RotationNormal {
 
 impl RotationNormal {
     /// Convert from degrees to this object.
+    #[must_use]
     pub fn from_degrees(deg: f64) -> Self {
         Self {
             degrees: deg % 360.0,
@@ -571,7 +521,7 @@ pub struct RotationAim {
     pub aim_target: i16,
     /// Rotation offset of the rotating group
     pub rot_offset: f64,
-    ///  Overrides aim_target if not None, uses either P1 or P2 as the target instead.
+    ///  Overrides `aim_target` if not None, uses either P1 or P2 as the target instead.
     pub player_target: Option<RotationPlayerTarget>,
 }
 
@@ -924,7 +874,7 @@ pub fn pulse_trigger(
     pulse_hold_time: f64,
     pulse_fade_out_time: f64,
     exclusive_pulse: bool,
-    pulse_target: PulseTarget,
+    pulse_target: &PulseTarget,
     pulse_mode: PulseMode,
 ) -> GDObject {
     let mut properties = vec![
@@ -975,7 +925,7 @@ pub fn pulse_trigger(
 /// * `target_group`: Target group to stop/pause/resume
 /// * `stop_mode`: Stop mode (see [`StopMode`] struct)
 /// * `use_control_id`: Only stops certain triggers within a group if enabled.
-#[inline(always)]
+#[inline]
 pub fn stop_trigger(
     config: &GDObjConfig,
     target_group: i16,
@@ -1000,7 +950,7 @@ pub fn stop_trigger(
 /// * `target_group`: Target group to stop/pause/resume
 /// * `opacity`: Opacity to set group at
 /// * `fade_time`: Time to fade to the opacity
-#[inline(always)]
+#[inline]
 pub fn alpha_trigger(
     config: &GDObjConfig,
     target_group: i16,
@@ -1024,7 +974,7 @@ pub fn alpha_trigger(
 /// * `config`: General object options, such as position and scale
 /// * `target_group`: Target group to stop/pause/resume
 /// * `activate_group`: Active group instead of deactivating?
-#[inline(always)]
+#[inline]
 pub fn toggle_trigger(config: &GDObjConfig, target_group: i16, activate_group: bool) -> GDObject {
     GDObject::new(
         TRIGGER_TOGGLE,
@@ -1065,7 +1015,7 @@ pub fn transition_object(
 /// Returns a reverse gameplay trigger
 /// # Arguments
 /// * `config`: General object options, such as position and scale
-#[inline(always)]
+#[inline]
 pub fn reverse_gameplay(config: &GDObjConfig) -> GDObject {
     GDObject::new(TRIGGER_REVERSE_GAMEPLAY, config, vec![])
 }
@@ -1074,7 +1024,7 @@ pub fn reverse_gameplay(config: &GDObjConfig) -> GDObject {
 /// # Arguments
 /// * `config`: General object options, such as position and scale
 /// * `target_group`: group that is linked visibly
-#[inline(always)]
+#[inline]
 pub fn link_visible(config: &GDObjConfig, target_group: i16) -> GDObject {
     GDObject::new(
         TRIGGER_LINK_VISIBLE,
@@ -1087,7 +1037,7 @@ pub fn link_visible(config: &GDObjConfig, target_group: i16) -> GDObject {
 /// # Arguments
 /// * `config`: General object options, such as position and scale
 /// * `time_scale`: How much to speed up/slow down time by. 1.0 is the default
-#[inline(always)]
+#[inline]
 pub fn timewarp(config: &GDObjConfig, time_scale: f64) -> GDObject {
     GDObject::new(
         TRIGGER_TIME_WARP,
@@ -1099,7 +1049,7 @@ pub fn timewarp(config: &GDObjConfig, time_scale: f64) -> GDObject {
 /// Returns a trigger that shows the player
 /// # Arguments
 /// * `config`: General object options, such as position and scale
-#[inline(always)]
+#[inline]
 pub fn show_player(config: &GDObjConfig) -> GDObject {
     GDObject::new(1613, config, vec![])
 }
@@ -1107,7 +1057,7 @@ pub fn show_player(config: &GDObjConfig) -> GDObject {
 /// Returns a trigger that hides the player
 /// # Arguments
 /// * `config`: General object options, such as position and scale
-#[inline(always)]
+#[inline]
 pub fn hide_player(config: &GDObjConfig) -> GDObject {
     GDObject::new(1612, config, vec![])
 }
@@ -1115,7 +1065,7 @@ pub fn hide_player(config: &GDObjConfig) -> GDObject {
 /// Returns a trigger that shows the player trail
 /// # Arguments
 /// * `config`: General object options, such as position and scale
-#[inline(always)]
+#[inline]
 pub fn show_player_trail(config: &GDObjConfig) -> GDObject {
     GDObject::new(ENABLE_PLAYER_TRAIL, config, vec![])
 }
@@ -1123,7 +1073,7 @@ pub fn show_player_trail(config: &GDObjConfig) -> GDObject {
 /// Returns a trigger that hides the player trail
 /// # Arguments
 /// * `config`: General object options, such as position and scale\
-#[inline(always)]
+#[inline]
 pub fn hide_player_trail(config: &GDObjConfig) -> GDObject {
     GDObject::new(DISABLE_PLAYER_TRAIL, config, vec![])
 }
@@ -1131,7 +1081,7 @@ pub fn hide_player_trail(config: &GDObjConfig) -> GDObject {
 /// Returns a trigger that enables the background effect
 /// # Arguments
 /// * `config`: General object options, such as position and scale
-#[inline(always)]
+#[inline]
 pub fn bg_effect_on(config: &GDObjConfig) -> GDObject {
     GDObject::new(BG_EFFECT_ON, config, vec![])
 }
@@ -1139,7 +1089,7 @@ pub fn bg_effect_on(config: &GDObjConfig) -> GDObject {
 /// Returns a trigger that disables the background effect
 /// # Arguments
 /// * `config`: General object options, such as position and scale
-#[inline(always)]
+#[inline]
 pub fn bg_effect_off(config: &GDObjConfig) -> GDObject {
     GDObject::new(BG_EFFECT_OFF, config, vec![])
 }
@@ -1148,7 +1098,7 @@ pub fn bg_effect_off(config: &GDObjConfig) -> GDObject {
 /// # Arguments
 /// * `config`: General object options, such as position and scale
 /// * `target_group`: group that is to be reset
-#[inline(always)]
+#[inline]
 pub fn group_reset(config: &GDObjConfig, target_group: i16) -> GDObject {
     GDObject::new(
         TRIGGER_RESET_GROUP,
@@ -1163,7 +1113,7 @@ pub fn group_reset(config: &GDObjConfig, target_group: i16) -> GDObject {
 /// * `strength`: Strength of shake
 /// * `interval`: Interval in seconds between each shake
 /// * `duration`: Total duration of shaking
-#[inline(always)]
+#[inline]
 pub fn shake_trigger(
     config: &GDObjConfig,
     strength: i32,
@@ -1186,7 +1136,7 @@ pub fn shake_trigger(
 /// * `config`: General object options, such as position and scale
 /// * `mod_x`: X-axis speed of BG in terms of player speed. Default is 0.3
 /// * `mod_y`: Y-axis speed of BG in terms of player speed. Default is 0.5
-#[inline(always)]
+#[inline]
 pub fn bg_speed(config: &GDObjConfig, mod_x: f64, mod_y: f64) -> GDObject {
     GDObject::new(
         BG_SPEED_CONFIG,
@@ -1203,7 +1153,7 @@ pub fn bg_speed(config: &GDObjConfig, mod_x: f64, mod_y: f64) -> GDObject {
 /// * `config`: General object options, such as position and scale
 /// * `mod_x`: X-axis speed of MG in terms of player speed. Default is 0.3
 /// * `mod_y`: Y-axis speed of MG in terms of player speed. Default is 0.5
-#[inline(always)]
+#[inline]
 pub fn mg_speed(config: &GDObjConfig, mod_x: f64, mod_y: f64) -> GDObject {
     GDObject::new(
         MG_SPEED_CONFIG,
@@ -1224,7 +1174,7 @@ pub fn mg_speed(config: &GDObjConfig, mod_x: f64, mod_y: f64) -> GDObject {
 /// * `stop_move`: Stops the player from moving
 /// * `stop_rotation`: Stops the player's rotation
 /// * `stop_slide`: Stops the player from sliding after a force
-#[inline(always)]
+#[inline]
 pub fn player_control(
     config: &GDObjConfig,
     p1: bool,
@@ -1308,7 +1258,7 @@ pub fn end_trigger(
 /// * `timer`: Is a timer?
 /// * `align`: Visual alignment of counter object. See [`ItemAlign`] struct.
 /// * `seconds_only`: Show only seconds if timer?
-/// * `special_mode`: Other special mode of timer. See CounterMode struct.
+/// * `special_mode`: Other special mode of timer. See [`CounterMode`] struct.
 pub fn counter_object(
     config: &GDObjConfig,
     item: Item,
@@ -1324,7 +1274,7 @@ pub fn counter_object(
         Item::Attempts | Item::MainTime | Item::Points => {
             properties.push((
                 SPECIAL_COUNTER_MODE,
-                GDValue::Int(item.as_special_mode_i32()),
+                GDValue::Int(item.as_special_mode_i32().unwrap_or(0)),
             ));
         }
         Item::Counter(c) => {
@@ -1563,7 +1513,7 @@ pub fn spawn_trigger(
 /// * `config`: General object options, such as position and scale
 /// * `target_group`: Spawns this group
 /// * `activate_group`: Activate this group (instead of toggling off)?
-#[inline(always)]
+#[inline]
 pub fn on_death(config: &GDObjConfig, target_group: i16, activate_group: bool) -> GDObject {
     GDObject::new(
         TRIGGER_ON_DEATH,
@@ -1626,7 +1576,7 @@ pub fn spawn_particle(
 /// * `config`: General object options, such as position and scale
 /// * `id`: Collision block ID
 /// * `dynamic`: Does this block register collisions with other collision blocks?
-#[inline(always)]
+#[inline]
 pub fn collision_block(config: &GDObjConfig, id: i16, dynamic: bool) -> GDObject {
     GDObject::new(
         COLLISION_BLOCK,
@@ -1646,7 +1596,7 @@ pub fn collision_block(config: &GDObjConfig, id: i16, dynamic: bool) -> GDObject
 /// * `claim_touch`: Disable buffer clicking?
 /// * `multi_activate`: Allow multiple activations?
 /// * `spawn_only`: Spawn only without toggling?
-#[inline(always)]
+#[inline]
 pub fn toggle_block(
     config: &GDObjConfig,
     target_group: i16,
@@ -1673,7 +1623,7 @@ pub fn toggle_block(
 /// * `config`: General object options, such as position and scale
 /// * `state_on`: Group that is activated when the player enters this block's hitbox
 /// * `state_off`: Group that is activated when the player exits this block's hitbox
-#[inline(always)]
+#[inline]
 pub fn state_block(config: &GDObjConfig, state_on: i16, state_off: i16) -> GDObject {
     GDObject::new(
         COLLISION_STATE_BLOCK,
@@ -1695,7 +1645,7 @@ pub fn state_block(config: &GDObjConfig, state_on: i16, state_off: i16) -> GDObj
 ///   instead of when they start colliding.
 ///
 /// **Note**: At least one of the collider blocks must be dynamic for this collision to register.
-#[inline(always)]
+#[inline]
 pub fn collision_trigger(
     config: &GDObjConfig,
     collider_cfg: ColliderConfig,
@@ -1737,7 +1687,7 @@ pub fn collision_trigger(
 /// * `collider_cfg`: Settings for colliders for this collision detection. See [`ColliderConfig`]
 /// * `true_id`: ID of group that is activated if the two colliders collide
 /// * `false_id`: ID of group that is activated if the two colliders do not collide
-#[inline(always)]
+#[inline]
 pub fn instant_coll_trigger(
     config: &GDObjConfig,
     collider_cfg: ColliderConfig,
@@ -1805,7 +1755,7 @@ pub fn time_trigger(
 /// * `config`: General object options, such as position and scale
 /// * `id`: Timer ID
 /// * `stop`: If enabled, stops the timer; otherwise, starts the timer.
-#[inline(always)]
+#[inline]
 pub fn time_control(config: &GDObjConfig, id: i16, stop: bool) -> GDObject {
     GDObject::new(
         TRIGGER_TIME_CONTROL,
@@ -1824,7 +1774,7 @@ pub fn time_control(config: &GDObjConfig, id: i16, stop: bool) -> GDObject {
 /// * `target_group`: If enabled, stops the timer; otherwise, starts the timer.
 /// * `target_time`: At what time the timer should be to activate objects in `target_group`.
 /// * `multi_activate`: Should this event be triggerable multiple times?
-#[inline(always)]
+#[inline]
 pub fn time_event(
     config: &GDObjConfig,
     id: i16,
@@ -1877,7 +1827,7 @@ pub fn camera_zoom(
 /// * `offset_x`: Center offset from this object in x axis
 /// * `offset_y`: Center offset from this object in y axis
 /// * `opacity`: Opacity of guidelines
-#[inline(always)]
+#[inline]
 pub fn camera_guide(
     config: &GDObjConfig,
     zoom: f64,
@@ -1907,7 +1857,7 @@ pub fn camera_guide(
 /// * `follow_time`: Time that the follow group is followed for. -1.0 = infinite.
 /// * `target_group`: Group that is following
 /// * `follow_group`: Group that is being followed
-#[inline(always)]
+#[inline]
 pub fn follow_trigger(
     config: &GDObjConfig,
     x_mod: f64,
@@ -1934,7 +1884,7 @@ pub fn follow_trigger(
 /// * `config`: General object options, such as position and scale
 /// * `target_group`: Objects to animate
 /// * `animation`: Animation ID, provided in [`Anim`] enum
-#[inline(always)]
+#[inline]
 pub fn animate_trigger(config: &GDObjConfig, target_group: i16, animation: Anim) -> GDObject {
     GDObject::new(
         TRIGGER_ANIMATE,
@@ -1954,7 +1904,7 @@ pub fn animate_trigger(config: &GDObjConfig, target_group: i16, animation: Anim)
 /// * `target_count`: Target count of item at `item_id`
 /// * `activate_group`: Whether or not to activate the target group
 /// * `multi_activate`: Whether or not this trigger is multi-activatable
-#[inline(always)]
+#[inline]
 pub fn count_trigger(
     config: &GDObjConfig,
     item_id: i16,
@@ -1984,7 +1934,7 @@ pub fn count_trigger(
 /// Chances are considered relative to each other, meaning that they are not
 /// precentage-based. Two groups with the same relative chance will have the same
 /// (50-50) chance to be triggered
-#[inline(always)]
+#[inline]
 pub fn advanced_random_trigger(config: &GDObjConfig, probabilities: Vec<(i16, i32)>) -> GDObject {
     GDObject::new(
         TRIGGER_ADVANCED_RANDOM,
@@ -2005,7 +1955,7 @@ pub fn advanced_random_trigger(config: &GDObjConfig, probabilities: Vec<(i16, i3
 /// * `y_reference`: Reference position for the element on the Y-axis
 /// * `x_ref_relative`: Whether or not the x-axis position scales with aspect ratio
 /// * `y_ref_relative`: Whether or not the y-axis position scales with aspect ratio
-#[inline(always)]
+#[inline]
 pub fn ui_config_trigger(
     config: &GDObjConfig,
     target_group: i16,
@@ -2155,7 +2105,7 @@ pub fn scale_trigger(
 /// * `max_speed`: Speed limit of the following group
 /// * `move_time`: How long the group will follow the player
 /// * `target_group`: The group that is following the player's y-pos
-#[inline(always)]
+#[inline]
 pub fn follow_player_y(
     config: &GDObjConfig,
     speed: f64,
@@ -2182,7 +2132,7 @@ pub fn follow_player_y(
 /// Returns a middleground config trigger
 /// # Arguments
 /// * `config`: General object options, such as position and scale
-#[inline(always)]
+#[inline]
 pub fn mg_config(
     config: &GDObjConfig,
     offset_y: i32,
@@ -2199,7 +2149,7 @@ fn add_easing(properties: &mut Vec<(u16, GDValue)>, easing: Option<(MoveEasing, 
         properties.extend_from_slice(&[
             (MOVE_EASING, GDValue::Easing(easing)),
             (EASING_RATE, GDValue::Float(rate)),
-        ])
+        ]);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
-#![doc = include_str!("../README.md")]
+#![warn(clippy::all)]
 #![deny(missing_docs)]
+#![doc = include_str!("../README.md")]
 
 pub mod core;
 pub mod deserialiser;
@@ -10,3 +11,5 @@ pub mod serialiser;
 
 #[cfg(test)]
 pub mod tests;
+
+pub use core::GDError;

--- a/src/rand.rs
+++ b/src/rand.rs
@@ -2,17 +2,19 @@
 
 use crate::gdobj::{GDValue, Group};
 
-const LCG_MULTIPLIER: u64 = 214013;
-const LCG_CONSTANT: u64 = 2531011;
+const LCG_MULTIPLIER: u64 = 214_013;
+const LCG_CONSTANT: u64 = 2_531_011;
 
 /// Determines the next seed from a starting seed as generated in Geometry Dash.
 #[inline(always)]
+#[must_use]
 pub fn next_seed(seed: u64) -> u64 {
     seed.wrapping_mul(LCG_MULTIPLIER).wrapping_add(LCG_CONSTANT)
 }
 
 /// Mutating version of [`next_seed`]
 #[inline(always)]
+#[must_use]
 pub fn next_seed_mut(seed: &mut u64) {
     *seed = seed.wrapping_mul(LCG_MULTIPLIER).wrapping_add(LCG_CONSTANT);
 }
@@ -20,12 +22,14 @@ pub fn next_seed_mut(seed: &mut u64) {
 /// Function used by GD to generate a new seed. Internally known as `fast_rand_0_1`.
 /// Unlike the actual PRNG used in GD, this function *DOES NOT* automatically update the seed.
 #[inline(always)]
+#[must_use]
 pub fn fast_rand_bits(seed: u64) -> u64 {
     (next_seed(seed) >> 16) & 0x7fff
 }
 
 /// Utility function which normalises result from [`fast_rand_bits`] to the range \[0.0, 1.0].
 #[inline(always)]
+#[must_use]
 pub fn fast_rand_bits_norm(seed: u64) -> f64 {
     fast_rand_bits(seed) as f64 / 32767.0
 }
@@ -41,6 +45,7 @@ pub fn fast_rand_bits_norm(seed: u64) -> f64 {
 /// **WARNING**: This function may rarely, for an unknown reason, erroneously determine that
 /// a seed will activate a group when in reality, it won't. Please be mindful of this when checking seeds.
 #[inline(always)]
+#[must_use]
 pub fn check_seed_random(seed: u64, chance: f64) -> bool {
     // Compare against the chance threshold
     fast_rand_bits_norm(seed) < chance
@@ -58,6 +63,7 @@ pub fn check_seed_random(seed: u64, chance: f64) -> bool {
 ///
 /// **WARNING**: This function may rarely, for an unknown reason, erroneously determine that
 /// a seed will activate a group when in reality, it won't. Please be mindful of this when checking seeds.
+#[must_use]
 pub fn check_seed_advanced_random(seed: u64, probabilities: &GDValue) -> Option<Group> {
     let prob_list;
     if let GDValue::ProbabilitiesList(probs) = probabilities {
@@ -87,7 +93,7 @@ pub fn check_seed_advanced_random(seed: u64, probabilities: &GDValue) -> Option<
 
     // Iterate through all groups until the threshold is reached.
     // If the threshold is never reached, the last group is activated.
-    for (group, chance) in prob_list.iter() {
+    for (group, chance) in prob_list {
         cumulative_chance += chance;
         if cumulative_chance as f64 >= threshold {
             chosen_group = *group;

--- a/src/serialiser.rs
+++ b/src/serialiser.rs
@@ -3,18 +3,21 @@ use std::{fmt::Write, io::Write as IoWrite};
 
 use flate2::{Compression, write::ZlibEncoder};
 use plist::{Dictionary, Value};
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
 
 use crate::core::b64_encode;
 
-fn zlib_compress(s: String) -> Vec<u8> {
+fn zlib_compress(s: &str) -> Vec<u8> {
     let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
     encoder.write_all(s.as_bytes()).unwrap();
     encoder.finish().unwrap()
 }
 
 /// Returns the encrypted level string as `Vec<u8>` from a `GDLevel` object string
-pub fn encrypt_level_str(s: String) -> Vec<u8> {
-    let compress = zlib_compress(s.clone());
+#[must_use]
+pub fn encrypt_level_str(s: &str) -> Vec<u8> {
+    let compress = zlib_compress(s);
     let mut data = b"H4sIAAAAAA".to_vec();
     data.extend_from_slice(&compress[2..compress.len() - 4]);
     let crc_checksum = crc32fast::hash(s.as_bytes()).to_le_bytes();
@@ -22,7 +25,7 @@ pub fn encrypt_level_str(s: String) -> Vec<u8> {
 
     data.extend_from_slice(&crc_checksum);
     data.extend_from_slice(&size);
-    let base64 = b64_encode(data).replace("+", "-").replace("/", "_");
+    let base64 = b64_encode(data);
 
     let mut header = b"H4sIAAAAAAAAC".to_vec();
     header.extend_from_slice(&base64.as_bytes()[13..]);
@@ -30,17 +33,27 @@ pub fn encrypt_level_str(s: String) -> Vec<u8> {
 }
 
 /// Returns the encrypted savefile string from a stringified `Levels` struct
-pub fn encrypt_savefile_str(s: String) -> Vec<u8> {
-    encrypt_level_str(s).iter().map(|c| *c ^ 11).collect()
+#[must_use]
+pub fn encrypt_savefile_str(s: &str) -> Vec<u8> {
+    let mut encrypted = encrypt_level_str(s);
+    #[cfg(feature = "parallel")]
+    encrypted.par_iter_mut().for_each(|c| *c ^= 0x000b);
+
+    #[cfg(not(feature = "parallel"))]
+    for byte in &mut encrypted {
+        *byte ^= 0x000b;
+    }
+    encrypted
 }
 
 /// Parses an XML dictionary to a string that matches GD savefile format.
 ///
 /// # Arguments
-/// * `dict`: plist::Dictionary to parse.
+/// * `dict`: `plist::Dictionary` to parse.
 /// * `root`: Is the input the root dict?
 ///
 /// Returns the stringified dictionary
+#[must_use]
 pub fn stringify_xml(dict: &Dictionary, root: bool) -> String {
     if dict.is_empty() {
         return "<d />".to_owned();
@@ -52,7 +65,7 @@ pub fn stringify_xml(dict: &Dictionary, root: bool) -> String {
         false => "<d>",
     });
 
-    for (key, value) in dict.iter() {
+    for (key, value) in dict {
         let _ = write!(dict_str, "<k>{key}</k>");
         match value {
             Value::String(s) => {

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -19,7 +19,7 @@ fn benchmark<F: Fn() -> R, R>(name: &str, f: F) -> R {
         "{name}: {:.3}ms",
         start.elapsed().as_micros() as f64 / 1000.0
     );
-    return result;
+    result
 }
 
 #[test]


### PR DESCRIPTION
Fixes include:
- Doc typos, clarifications, backticks, etc.
- #[must_use], #[non_exhaustive], #[derive(Copy)], etc. where needed
- Removed owned T params where a borrowed &T value was better
- Added a `parallel` feature with rayon to cut down time
- many many performance fixes